### PR TITLE
Stop supporting services

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ end
 | Nested messages         | ✓                          |
 | Maps                    | ✓                          |
 | Extensions              | ✓                          |
-| Services                | Generates stubs            |
+| Services                | Only generates classes     |
 | Oneof                   | No support in `protobuf` gem |
 
 ## Development

--- a/lib/rbs_protobuf/translator/protobuf_gem.rb
+++ b/lib/rbs_protobuf/translator/protobuf_gem.rb
@@ -576,65 +576,7 @@ module RBSProtobuf
           comment: comment_for_path(source_code_info, path),
           location: nil,
           annotations: []
-        ).tap do |service_decl|
-          requests = []
-          responses = []
-
-          service.method.each.with_index do |method, index|
-            requests << message_type(method.input_type)
-            responses << message_type(method.output_type)
-
-            service_decl.members << RBS::AST::Members::MethodDefinition.new(
-              name: ActiveSupport::Inflector.underscore(method.name).to_sym,
-              kind: :instance,
-              types: [factory.method_type(type: factory.function())],
-              annotations: [],
-              location: nil,
-              comment: comment_for_path(source_code_info, path + [2, index]),
-              overload: false
-            )
-          end
-
-          unless requests.empty?
-            service_decl.members << RBS::AST::Members::MethodDefinition.new(
-              name: :request,
-              kind: :instance,
-              types: [
-                factory.method_type(
-                  type: factory.function(
-                    factory.union_type(*requests)
-                  )
-                )
-              ],
-              annotations: [],
-              location: nil,
-              comment: nil,
-              overload: false
-            )
-          end
-
-          unless responses.empty?
-            service_decl.members << RBS::AST::Members::MethodDefinition.new(
-              name: :response,
-              kind: :instance,
-              types: [
-                factory.method_type(
-                  type: factory.function().update(
-                    required_positionals: [
-                      factory.param(
-                        factory.union_type(*responses)
-                      )
-                    ]
-                  )
-                )
-              ],
-              annotations: [],
-              location: nil,
-              comment: nil,
-              overload: false
-            )
-          end
-        end
+        )
       end
     end
   end

--- a/test/protobuf_gem_test.rb
+++ b/test/protobuf_gem_test.rb
@@ -653,13 +653,6 @@ class Message < ::Protobuf::Message
 end
 
 class SearchService < ::Protobuf::Rpc::Service
-  def search: () -> void
-
-  def send_message: () -> void
-
-  def request: () -> (::SearchRequest | ::Message)
-
-  def response: (::SearchResponse | ::Message) -> void
 end
 RBS
   end


### PR DESCRIPTION
It's really difficult to give types to services in protobuf gem.

```ruby
module Foo
  class UserService
    # request -> Foo::UserRequest
    # response -> Foo::UserResponse
    def find
      request                          # returns Foo::UserRequest
      respond_with(:users => users)    # #respond_with accepts UserResponses
    end

    # request -> Foo::UpdateRequest
    # response -> Foo::UpdateResponse
    def update
      request                          # returns UpdateRequest here
      respond_with(:user => user)      # #respond_with accepts UpdateResponse here
    end
  end
end
```

It is because the `#request` and `#respond_with` methods have different types in each service method. We can give types using union types of all possible requests and responses, but it doesn't make much sense.

So, rbs_protobuf currently doesn't support generating types for service methods. It only generates classes.