### PR TITLE
Generate bool type for true | false

### DIFF
--- a/lib/rbs_protobuf/translator/base.rb
+++ b/lib/rbs_protobuf/translator/base.rb
@@ -76,8 +76,7 @@ module RBSProtobuf
         when FieldDescriptorProto::Type::TYPE_DOUBLE, FieldDescriptorProto::Type::TYPE_FLOAT
           RBS::BuiltinNames::Float.instance_type
         when FieldDescriptorProto::Type::TYPE_BOOL
-          factory.union_type(factory.literal_type(true),
-                             factory.literal_type(false))
+          factory.bool_type()
         else
           raise "Unknown base type: #{type}"
         end

--- a/test/protobuf_gem_test.rb
+++ b/test/protobuf_gem_test.rb
@@ -66,16 +66,16 @@ EOP
 
     assert_equal <<RBS, content
 class Message < ::Protobuf::Message
-  attr_reader name(): true | false
+  attr_reader name(): bool
 
-  attr_writer name(): (true | false)?
+  attr_writer name(): bool?
 
-  def initialize: (?name: (true | false)?) -> void
+  def initialize: (?name: bool?) -> void
 
-  def []: (:name) -> (true | false)
+  def []: (:name) -> bool
         | (::Symbol) -> untyped
 
-  def []=: (:name, (true | false)?) -> (true | false)?
+  def []=: (:name, bool?) -> bool?
          | (::Symbol, untyped) -> untyped
 
   def name?: () -> bool


### PR DESCRIPTION
`bool` in RBS is now `true | false`. Updating rbs_protobuf to use `bool`.