### PR TITLE
Add option to control `extend` processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ end
 * `RBS_PROTOBUF_BACKEND` specifies the Ruby code generator gem. Supported value is `protobuf`. (We will add `google-protobuf` for `google-protobuf` gem.)
 * `PB_UPCASE_ENUMS` is for `protobuf` gem support. Specify the environment variable to make enum value constants upper case.
 * `RBS_PROTOBUF_NO_NESTED_NAMESPACE` is to make the RBS declarations flat.
+* `RBS_PROTOBUF_EXTENSION` specifies what to do for extensions.
 
 ## Supported features
 
@@ -116,9 +117,35 @@ end
 | Packages                | ✓                          |
 | Nested messages         | ✓                          |
 | Maps                    | ✓                          |
-| Extensions              | ✓                          |
+| Extensions              | Read next section          |
 | Services                | Only generates classes     |
 | Oneof                   | No support in `protobuf` gem |
+
+### Extensions
+
+Adding extensions may cause problems if the name of new attribute conflicts.
+
+```proto
+extend SearchRequest {
+  // This extension defines an attribute.
+  optional string option = 100;
+}
+
+extend SearchRequest {
+  // Another extension defines another attribute with same name.
+  optional string option = 101;
+}
+```
+
+In this case, defining two `option` attributes in RBS causes an error.
+So, rbs_protobuf allows ignoring extensions for this case.
+
+You can control the behaviour with `RBS_PROTOBUF_EXTENSION` environment variable.
+
+* `false`: Ignores extensions.
+* `print`: Prints RBS for extensions instead of writing them to files. You can copy or modify the printed RBS, and put them in some RBS files.
+* Any value else: Generates RBS for extensions.
+* undefined: Ignores extensions but print messages to ask you to specify a value.
 
 ## Development
 

--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ namespace :example do
       "example/b.proto"
     )
     sh(
-      { "RBS_PROTOBUF_BACKEND" => "protobuf" },
+      { "RBS_PROTOBUF_BACKEND" => "protobuf", "RBS_PROTOBUF_EXTENSION" => "true" },
       "protoc",
       "--rbs_out=example/protobuf-gem",
       "-Iexample",

--- a/exe/protoc-gen-rbs
+++ b/exe/protoc-gen-rbs
@@ -19,11 +19,22 @@ translator = case backend
              when "protobuf"
                upcase_enum = ENV.key?("PB_UPCASE_ENUMS")
                no_nested_namespace = ENV.key?("RBS_PROTOBUF_NO_NESTED_NAMESPACE")
+               extension = case ENV["RBS_PROTOBUF_EXTENSION"]
+                           when "false"
+                             false
+                           when nil
+                             nil
+                           when "print"
+                             :print
+                           else
+                             true
+                           end
 
                RBSProtobuf::Translator::ProtobufGem.new(
                  input,
                  upcase_enum: upcase_enum,
-                 nested_namespace: !no_nested_namespace
+                 nested_namespace: !no_nested_namespace,
+                 extension: extension
                )
              when "google-protobuf"
                raise NotImplementedError

--- a/lib/rbs_protobuf/translator/protobuf_gem.rb
+++ b/lib/rbs_protobuf/translator/protobuf_gem.rb
@@ -1,10 +1,26 @@
 module RBSProtobuf
   module Translator
     class ProtobufGem < Base
-      def initialize(input, upcase_enum:, nested_namespace:)
+      attr_reader :stderr
+
+      def initialize(input, upcase_enum:, nested_namespace:, extension:, stderr: STDERR)
         super(input)
         @upcase_enum = upcase_enum
         @nested_namespace = nested_namespace
+        @extension = extension
+        @stderr = stderr
+      end
+
+      def ignore_extension?
+        !@extension
+      end
+
+      def print_extension_message?
+        @extension == nil
+      end
+
+      def print_extension?
+        @extension == :print
       end
 
       def upcase_enum?
@@ -75,11 +91,27 @@ module RBSProtobuf
         end
 
         file.extension.group_by(&:extendee).each.with_index do |(name, extensions), index|
-          decls.push(*extension_to_decl(name,
-                                        extensions,
-                                        prefix: RBS::Namespace.root,
-                                        source_code_info: source_code_info,
-                                        path: [7, index]))
+          if ignore_extension?
+            if print_extension_message?
+              stderr.puts "Extension for `#{name}` ignored in `#{file.name}`; Set RBS_PROTOBUF_EXTENSION env var to generate RBS for extensions."
+            end
+          else
+            exts = extension_to_decl(name,
+                                     extensions,
+                                     prefix: RBS::Namespace.root,
+                                     source_code_info: source_code_info,
+                                     path: [7, index])
+
+            if print_extension?
+              stderr.puts "#=========================================================="
+              stderr.puts "# Printing RBS for extensions from #{file.name}"
+              stderr.puts "#"
+              RBS::Writer.new(out: stderr).write(exts)
+              stderr.puts
+            else
+              decls.push(*exts)
+            end
+          end
         end
 
         StringIO.new.tap do |io|

--- a/lib/rbs_protobuf/translator/protobuf_gem.rb
+++ b/lib/rbs_protobuf/translator/protobuf_gem.rb
@@ -108,7 +108,6 @@ module RBSProtobuf
 
       def message_to_decl(message, prefix:, message_path:, source_code_info:, path:)
         class_name = ActiveSupport::Inflector.upcase_first(message.name)
-        decl_namespace = prefix.append(class_name.to_sym)
 
         RBS::AST::Declarations::Class.new(
           name: RBS::TypeName.new(name: class_name.to_sym, namespace: prefix),

--- a/test/protobuf_gem_test.rb
+++ b/test/protobuf_gem_test.rb
@@ -17,7 +17,8 @@ EOP
     translator = RBSProtobuf::Translator::ProtobufGem.new(
       input,
       upcase_enum: true,
-      nested_namespace: true
+      nested_namespace: true,
+      extension: false
     )
     content = translator.rbs_content(input.proto_file[0])
 
@@ -60,7 +61,8 @@ EOP
     translator = RBSProtobuf::Translator::ProtobufGem.new(
       input,
       upcase_enum: true,
-      nested_namespace: true
+      nested_namespace: true,
+      extension: false
     )
     content = translator.rbs_content(input.proto_file[0])
 
@@ -100,7 +102,8 @@ EOP
     translator = RBSProtobuf::Translator::ProtobufGem.new(
       input,
       upcase_enum: false,
-      nested_namespace: true
+      nested_namespace: true,
+      extension: false
     )
     content = translator.rbs_content(input.proto_file[0])
 
@@ -146,7 +149,8 @@ EOP
     translator = RBSProtobuf::Translator::ProtobufGem.new(
       input,
       upcase_enum: false,
-      nested_namespace: true
+      nested_namespace: true,
+      extension: false
     )
     content = translator.rbs_content(input.proto_file[0])
 
@@ -185,7 +189,8 @@ EOP
     translator = RBSProtobuf::Translator::ProtobufGem.new(
       input,
       upcase_enum: false,
-      nested_namespace: true
+      nested_namespace: true,
+      extension: false
     )
     content = translator.rbs_content(input.proto_file[0])
 
@@ -228,7 +233,8 @@ EOP
     translator = RBSProtobuf::Translator::ProtobufGem.new(
       input,
       upcase_enum: true,
-      nested_namespace: true
+      nested_namespace: true,
+      extension: false
     )
     content = translator.rbs_content(input.proto_file[0])
 
@@ -290,7 +296,8 @@ EOP
     translator = RBSProtobuf::Translator::ProtobufGem.new(
       input,
       upcase_enum: true,
-      nested_namespace: true
+      nested_namespace: true,
+      extension: false
     )
     content = translator.rbs_content(input.proto_file[0])
 
@@ -332,7 +339,8 @@ EOP
     translator = RBSProtobuf::Translator::ProtobufGem.new(
       input,
       upcase_enum: true,
-      nested_namespace: false
+      nested_namespace: false,
+      extension: false
     )
     content = translator.rbs_content(input.proto_file[0])
 
@@ -360,7 +368,8 @@ EOP
     translator = RBSProtobuf::Translator::ProtobufGem.new(
       input,
       upcase_enum: true,
-      nested_namespace: true
+      nested_namespace: true,
+      extension: false
     )
     content = translator.rbs_content(input.proto_file[0])
 
@@ -400,7 +409,8 @@ EOP
     translator = RBSProtobuf::Translator::ProtobufGem.new(
       input,
       upcase_enum: true,
-      nested_namespace: true
+      nested_namespace: true,
+      extension: false
     )
     content = translator.rbs_content(input.proto_file[0])
 
@@ -442,7 +452,8 @@ EOP
     translator = RBSProtobuf::Translator::ProtobufGem.new(
       input,
       upcase_enum: true,
-      nested_namespace: true
+      nested_namespace: true,
+      extension: false
     )
     content = translator.rbs_content(input.proto_file[0])
 
@@ -495,7 +506,8 @@ EOP
     translator = RBSProtobuf::Translator::ProtobufGem.new(
       input,
       upcase_enum: true,
-      nested_namespace: true
+      nested_namespace: true,
+      extension: false
     )
     content = translator.rbs_content(input.proto_file[0])
 
@@ -534,7 +546,8 @@ EOP
     translator = RBSProtobuf::Translator::ProtobufGem.new(
       input,
       upcase_enum: true,
-      nested_namespace: true
+      nested_namespace: true,
+      extension: false
     )
     content = translator.rbs_content(input.proto_file[0])
 
@@ -574,7 +587,8 @@ EOP
     translator = RBSProtobuf::Translator::ProtobufGem.new(
       input,
       upcase_enum: true,
-      nested_namespace: true
+      nested_namespace: true,
+      extension: false
     )
     content = translator.rbs_content(input.proto_file[0])
 
@@ -635,7 +649,8 @@ EOP
     translator = RBSProtobuf::Translator::ProtobufGem.new(
       input,
       upcase_enum: true,
-      nested_namespace: true
+      nested_namespace: true,
+      extension: false
     )
     content = translator.rbs_content(input.proto_file[0])
 
@@ -678,7 +693,8 @@ EOP
     translator = RBSProtobuf::Translator::ProtobufGem.new(
       input,
       upcase_enum: true,
-      nested_namespace: true
+      nested_namespace: true,
+      extension: true
     )
     content = translator.rbs_content(input.proto_file[0])
 
@@ -710,6 +726,95 @@ class ::Test::M1
   def []=: (:parent, ::Test::M1?) -> ::Test::M1?
          | ...
 end
+RBS
+  end
+
+  def test_extension_ignore
+    input = read_proto(<<EOP)
+syntax = "proto2";
+
+package test;
+
+message M1 {
+  extensions 100 to max;
+}
+
+extend M1 {
+  optional string name = 100;
+}
+EOP
+    stderr = StringIO.new
+
+    translator = RBSProtobuf::Translator::ProtobufGem.new(
+      input,
+      upcase_enum: true,
+      nested_namespace: true,
+      extension: nil,
+      stderr: stderr
+    )
+    content = translator.rbs_content(input.proto_file[0])
+
+    assert_equal <<RBS, content
+module Test
+  class M1 < ::Protobuf::Message
+    def initialize: () -> void
+  end
+end
+RBS
+    assert_equal <<RBS, stderr.string
+Extension for `.test.M1` ignored in `a.proto`; Set RBS_PROTOBUF_EXTENSION env var to generate RBS for extensions.
+RBS
+  end
+
+  def test_extension_print
+    input = read_proto(<<EOP)
+syntax = "proto2";
+
+package test;
+
+message M1 {
+  extensions 100 to max;
+}
+
+extend M1 {
+  optional string name = 100;
+}
+EOP
+    stderr = StringIO.new
+
+    translator = RBSProtobuf::Translator::ProtobufGem.new(
+      input,
+      upcase_enum: true,
+      nested_namespace: true,
+      extension: :print,
+      stderr: stderr
+    )
+    content = translator.rbs_content(input.proto_file[0])
+
+    assert_equal <<RBS, content
+module Test
+  class M1 < ::Protobuf::Message
+    def initialize: () -> void
+  end
+end
+RBS
+
+    assert_equal <<RBS, stderr.string
+#==========================================================
+# Printing RBS for extensions from a.proto
+#
+class ::Test::M1
+  attr_reader name(): ::String
+
+  attr_writer name(): ::String?
+
+  def []: (:name) -> ::String
+        | ...
+
+  def []=: (:name, ::String?) -> ::String?
+         | ...
+end
+
 RBS
   end
 end


### PR DESCRIPTION
Generating RBS for extension may cause errors if an attribute is defined with the same name in different extensions.

```proto
extend SearchRequest {
  // This extension defines an attribute.
  optional string option = 100;
}

extend SearchRequest {
  // Another extension defines another attribute with same name.
  optional string option = 101;
}
```

Generating two `#option` method definitions in RBS results in an error.

This PR is to let rbs_protobuf give three options to handle extensions.

1. Ignore extensions.
2. Generate definitions for extensions. (May generate valid or invalid RBS.)
3. Print RBS for extensions so that users can use them to define their custom RBS for extensions.