### PR TITLE
Put options in RBS files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,5 +38,3 @@ jobs:
           bin/setup
           bundle exec rake
           bundle exec rake install
-          mkdir -p tmp/out
-          RBS_PROTOBUF_BACKEND=protobuf protoc --rbs_out=tmp/out -Iexample example/*.proto

--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,9 @@ task :default => [:test, "example:typecheck"]
 namespace :example do
   desc "Generate Ruby code with protobuf-gem"
   task :protobufgem do
+    spec = Gem::Specification.find_by_name("protobuf")
+    proto_path = File.join(spec.gem_dir, "proto")
+
     sh("rm -rf example/protobuf-gem")
     sh("mkdir", "-p", "example/protobuf-gem")
     sh(
@@ -21,8 +24,10 @@ namespace :example do
       "--plugin=protoc-gen-ruby-protobuf=#{__dir__}/bin/protoc-gen-ruby",
       "--ruby-protobuf_out=example/protobuf-gem",
       "-Iexample",
+      "-I#{proto_path}",
       "example/a.proto",
-      "example/b.proto"
+      "example/b.proto",
+      "example/c.proto"
     )
     sh(
       { "RBS_PROTOBUF_BACKEND" => "protobuf", "RBS_PROTOBUF_EXTENSION" => "true" },
@@ -31,6 +36,14 @@ namespace :example do
       "-Iexample",
       "example/a.proto",
       "example/b.proto"
+    )
+    sh(
+      { "RBS_PROTOBUF_BACKEND" => "protobuf", "RBS_PROTOBUF_EXTENSION" => "true", "RUBYOPT" => "-rbundler/setup -Iexample/protobuf-gem -rc.pb" },
+      "protoc",
+      "--rbs_out=example/protobuf-gem",
+      "-Iexample",
+      "-I#{proto_path}",
+      "example/c.proto"
     )
   end
 

--- a/example/Steepfile
+++ b/example/Steepfile
@@ -2,9 +2,9 @@ D = Steep::Diagnostic
 
 target :lib do
   collection_config "../rbs_collection.yaml"
-  
+
   signature "protobuf-gem"
-  check "protobuf_gem_example.rb", "protobuf-gem"
+  check "protobuf_gem_example.rb"
 
   configure_code_diagnostics do |hash|
     hash[D::Ruby::FallbackAny] = :hint

--- a/example/c.proto
+++ b/example/c.proto
@@ -1,0 +1,12 @@
+syntax = "proto2";
+
+import "google/protobuf/descriptor.proto";
+
+extend google.protobuf.FieldOptions {
+  optional bool super_custom_option = 22300;
+}
+
+message Message {
+  option deprecated = true;
+  optional string name = 1 [(super_custom_option) = true];
+}

--- a/lib/rbs_protobuf/translator/protobuf_gem.rb
+++ b/lib/rbs_protobuf/translator/protobuf_gem.rb
@@ -146,7 +146,7 @@ module RBSProtobuf
           super_class: message_base_class,
           type_params: [],
           location: nil,
-          comment: comment_for_path(source_code_info, path),
+          comment: comment_for_path(source_code_info, path, options: message.options),
           members: [],
           annotations: []
         ).tap do |class_decl|
@@ -182,7 +182,7 @@ module RBSProtobuf
 
           message.field.each_with_index do |field, index|
             field_name = field.name.to_sym
-            comment = comment_for_path(source_code_info, path + [2, index])
+            comment = comment_for_path(source_code_info, path + [2, index], options: field.options)
 
             read_type, write_type = field_type(field, maps)
 
@@ -428,7 +428,7 @@ module RBSProtobuf
           super_class: enum_base_class(),
           type_params: factory.module_type_params(),
           members: [],
-          comment: comment_for_path(source_code_info, path),
+          comment: comment_for_path(source_code_info, path, options: enum_type.options),
           location: nil,
           annotations: []
         ).tap do |enum_decl|
@@ -505,7 +505,7 @@ module RBSProtobuf
           )
 
           enum_type.value.each.with_index do |v, index|
-            comment = comment_for_path(source_code_info, path + [2, index])
+            comment = comment_for_path(source_code_info, path + [2, index], options: v.options)
 
             enum_decl.members << RBS::AST::Declarations::Constant.new(
               name: factory.type_name(enum_name(v.name).to_s),
@@ -622,7 +622,7 @@ module RBSProtobuf
           super_class: service_base_class,
           type_params: factory.module_type_params(),
           members: [],
-          comment: comment_for_path(source_code_info, path),
+          comment: comment_for_path(source_code_info, path, options: nil),
           location: nil,
           annotations: []
         )

--- a/sig/rbs_protobuf/translator/base.rbs
+++ b/sig/rbs_protobuf/translator/base.rbs
@@ -23,7 +23,9 @@ module RBSProtobuf
 
       def rbs_content: (String file) -> String
 
-      def comment_for_path: (untyped source_code_info, Array[Integer] path) -> RBS::AST::Comment?
+      def comment_for_path: (untyped source_code_info, Array[Integer] path, options: untyped) -> RBS::AST::Comment?
+
+      def each_options_field: (untyped) { (Symbol, untyped) -> void } -> void
 
       def base_type: (untyped `type`) -> RBS::Types::t
 

--- a/test/protobuf_gem_test.rb
+++ b/test/protobuf_gem_test.rb
@@ -209,6 +209,10 @@ EOP
     content = translator.rbs_content(input.proto_file[0])
 
     assert_equal <<RBS, content
+# Protobuf options:
+#
+# - `allow_alias = true`
+#
 class Type < ::Protobuf::Enum
   type names = :Foo | :BAR
 
@@ -855,6 +859,55 @@ class ::Test::M1
          | ...
 end
 
+RBS
+  end
+
+  def test_message_with_options
+    input = read_proto(<<EOP)
+syntax = "proto2";
+
+message Message {
+  option deprecated = true;
+  optional string name = 1 [deprecated = true];
+}
+EOP
+
+    translator = RBSProtobuf::Translator::ProtobufGem.new(
+      input,
+      upcase_enum: true,
+      nested_namespace: true,
+      extension: false
+    )
+    content = translator.rbs_content(input.proto_file[0])
+
+    assert_equal <<RBS, content
+# Protobuf options:
+#
+# - `deprecated = true`
+#
+class Message < ::Protobuf::Message
+  # Protobuf options:
+  #
+  # - `deprecated = true`
+  #
+  attr_reader name(): ::String
+
+  # Protobuf options:
+  #
+  # - `deprecated = true`
+  #
+  attr_writer name(): ::String?
+
+  def name!: () -> ::String?
+
+  def initialize: (?name: ::String?) -> void
+
+  def []: (:name) -> ::String
+        | (::Symbol) -> untyped
+
+  def []=: (:name, ::String?) -> ::String?
+         | (::Symbol, untyped) -> untyped
+end
 RBS
   end
 end


### PR DESCRIPTION
rbs_protobuf have ignored protobuf _options_ because the usage of the options so widely varies that we cannot generate type definitions for them. This patch is to generate RBS comments of protobuf options like:

```proto
syntax = "proto2";

message Message {
  option deprecated = true;
  optional string name = 1 [deprecated = true];
}
```

generates:

```rbs
# Protobuf options:
#
# - `deprecated = true`
#
class Message < ::Protobuf::Message
  # Protobuf options:
  #
  # - `deprecated = true`
  #
  attr_reader name(): ::String

  # Protobuf options:
  #
  # - `deprecated = true`
  #
  attr_writer name(): ::String?

  def name!: () -> ::String?

  def initialize: (?name: ::String?) -> void

  def []: (:name) -> ::String
        | (::Symbol) -> untyped

  def []=: (:name, ::String?) -> ::String?
         | (::Symbol, untyped) -> untyped
end
```

And you can find which options are specified if you read the RBS files.

If you are using _custom_ options, you have to load the definition of custom options. It would be typically like the following:

```sh
$ RUBYOPT="-rbundler/setup -Ilib -rprotos/custom-option.pb" \.  # Set RUBYOPT to load the definition of custom options
  RBS_PROTOBUF_BACKEND=protobuf \
  bundle exec protoc --rbs_out=. ......
```