### PR TITLE
Use git submodule for gem_rbs_collection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,9 @@ jobs:
           unzip protoc-${{ matrix.protoc_version }}-linux-x86_64.zip
           mv bin/protoc /usr/local/bin/protoc
           protoc --version
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
       - name: Run test
         run: |
           ruby -v

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/gem_rbs_collection"]
+	path = vendor/gem_rbs_collection
+	url = git@github.com:ruby/gem_rbs_collection.git

--- a/Steepfile
+++ b/Steepfile
@@ -2,6 +2,7 @@ D = Steep::Diagnostic
 
 target :lib do
   signature "sig"
+  signature "vendor/gem_rbs_collection/gems/protobuf"
   check "lib"
 
   configure_code_diagnostics do |hash|

--- a/example/Steepfile
+++ b/example/Steepfile
@@ -4,6 +4,7 @@ target :lib do
   collection_config "../rbs_collection.yaml"
 
   signature "protobuf-gem"
+  signature "../vendor/gem_rbs_collection/gems/protobuf"
   check "protobuf_gem_example.rb"
 
   configure_code_diagnostics do |hash|

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -18,14 +18,6 @@ gems:
     revision: c7b9329222debd0b8a4a85c0ccdae6588fedd57a
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
-- name: protobuf
-  version: 3.10.3
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: c7b9329222debd0b8a4a85c0ccdae6588fedd57a
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
 - name: ast
   version: '2.4'
   source:

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -14,5 +14,6 @@ gems:
   - name: rbs
   - name: activesupport
   - name: protobuf
+    ignore: true
   - name: rbs_protobuf
     ignore: true


### PR DESCRIPTION
We will edit the `protobuf` gem RBS files in the repository, so having the repository as a submodule would be better than just installing with `rbs collection` command.