### PR TITLE
Refactor with name

### DIFF
--- a/lib/rbs_protobuf.rb
+++ b/lib/rbs_protobuf.rb
@@ -14,6 +14,7 @@ module RBSProtobuf
   @logger = Logger.new(STDERR)
 end
 
+require "rbs_protobuf/name"
 require "rbs_protobuf/rbs_factory"
 require "rbs_protobuf/translator/base"
 require "rbs_protobuf/translator/protobuf_gem"

--- a/lib/rbs_protobuf/name.rb
+++ b/lib/rbs_protobuf/name.rb
@@ -1,0 +1,68 @@
+module RBSProtobuf
+  module Name
+    class Class
+      attr_reader :name
+
+      def initialize(name)
+        raise unless name.class?
+        @name = name
+      end
+
+      def instance_type(*args)
+        RBS::Types::ClassInstance.new(name: name, args: args, location: nil)
+      end
+
+      alias [] instance_type
+
+      def singleton_type
+        RBS::Types::ClassSingleton.new(name: name, location: nil)
+      end
+
+      def instance_type?(t)
+        t.is_a?(RBS::Types::ClassInstance) && t.name == name
+      end
+
+      def singleton_type?(t)
+        t.is_a?(RBS::Types::ClassSingleton) && t.name == name
+      end
+
+      def super_class(*args)
+        RBS::AST::Declarations::Class::Super.new(name: name, args: args, location: nil)
+      end
+    end
+
+    class Alias
+      attr_reader :name
+
+      def initialize(name)
+        raise unless name.alias?
+        @name = name
+      end
+
+      def [](*args)
+        RBS::Types::Alias.new(name: name, args: args, location: nil)
+      end
+
+      def type?(t)
+        t.is_a?(RBS::Types::Alias) && t.name == name
+      end
+    end
+
+    class Interface
+      attr_reader :name
+
+      def initialize(name)
+        raise unless name.interface?
+        @name = name
+      end
+
+      def [](*args)
+        RBS::Types::Interface.new(name: name, args: args, location: nil)
+      end
+
+      def type?(t)
+        t.is_a?(RBS::Types::Interface) && t.name == name
+      end
+    end
+  end
+end

--- a/sig/rbs_protobuf/name.rbs
+++ b/sig/rbs_protobuf/name.rbs
@@ -1,0 +1,45 @@
+module RBSProtobuf
+  module Name
+    class Class
+      attr_reader name: RBS::TypeName
+
+      def initialize: (RBS::TypeName) -> void
+
+      def instance_type: (*RBS::Types::t args) -> RBS::Types::ClassInstance
+
+      def singleton_type: () -> RBS::Types::ClassSingleton
+
+      def instance_type?: (RBS::Types::t) -> bool
+
+      def singleton_type?: (RBS::Types::t) -> bool
+
+      alias [] instance_type
+
+      def super_class: (*RBS::Types::t args) -> RBS::AST::Declarations::Class::Super
+    end
+
+    class Alias
+      attr_reader name: RBS::TypeName
+
+      def initialize: (RBS::TypeName) -> void
+
+      def []: (*RBS::Types::t args) -> RBS::Types::Alias
+
+      def type?: (RBS::Types::t) -> bool
+
+      alias === type?
+    end
+
+    class Interface
+      attr_reader name: RBS::TypeName
+
+      def initialize: (RBS::TypeName) -> void
+
+      def []: (*RBS::Types::t args) -> RBS::Types::Interface
+
+      def type?: (RBS::Types::t) -> bool
+
+      alias === type?
+    end
+  end
+end

--- a/sig/rbs_protobuf/translator/protobuf_gem.rbs
+++ b/sig/rbs_protobuf/translator/protobuf_gem.rbs
@@ -1,6 +1,18 @@
 module RBSProtobuf
   module Translator
     class ProtobufGem < Base
+      # Protobuf::Field::FieldArray[R, W]
+      FIELD_ARRAY: Name::Class
+
+      # Protobuf::Field::FieldHash[K, RV, WV]
+      FIELD_HASH: Name::Class
+
+      # Protobuf::Enum
+      ENUM: Name::Class
+
+      # Protobuf::Message
+      MESSAGE: Name::Class
+
       attr_reader stderr: IO
 
       def initialize: (

--- a/sig/rbs_protobuf/translator/protobuf_gem.rbs
+++ b/sig/rbs_protobuf/translator/protobuf_gem.rbs
@@ -13,7 +13,7 @@ module RBSProtobuf
 
       @upcase_enum: bool
 
-      @pnested_namespace: bool
+      @nested_namespace: bool
 
       @extension: bool | :print | nil
 


### PR DESCRIPTION
This PR introduces three classes under `Protobuf::Name` module and use the classes to represent the type names.