### PR TITLE
Use overload for field write types

### DIFF
--- a/lib/rbs_protobuf/translator/protobuf_gem.rb
+++ b/lib/rbs_protobuf/translator/protobuf_gem.rb
@@ -356,34 +356,30 @@ module RBSProtobuf
       end
 
       def add_field(members, name:, read_type:, write_types:, comment:)
-        if write_types.empty?
-          members << RBS::AST::Members::AttrAccessor.new(
-            name: name,
-            type: read_type,
-            comment: comment,
-            location: nil,
-            annotations: [],
-            ivar_name: false,
-            kind: :instance
-          )
-        else
-          members << RBS::AST::Members::AttrReader.new(
-            name: name,
-            type: read_type,
-            comment: comment,
-            location: nil,
-            annotations: [],
-            ivar_name: false,
-            kind: :instance
-          )
+        members << RBS::AST::Members::AttrAccessor.new(
+          name: name,
+          type: read_type,
+          comment: comment,
+          location: nil,
+          annotations: [],
+          ivar_name: false,
+          kind: :instance
+        )
 
-          members << RBS::AST::Members::AttrWriter.new(
-            name: name,
-            type: factory.union_type(read_type, *write_types),
+        write_types.each do |write_type|
+          members << RBS::AST::Members::MethodDefinition.new(
+            name: :"#{name}=",
+            types: [
+              factory.method_type(
+                type: factory.function(write_type).update(
+                  required_positionals:[factory.param(write_type)]
+                )
+              )
+            ],
+            annotations: [],
             comment: comment,
             location: nil,
-            annotations: [],
-            ivar_name: false,
+            overload: true,
             kind: :instance
           )
         end

--- a/sig/rbs_protobuf/translator/protobuf_gem.rbs
+++ b/sig/rbs_protobuf/translator/protobuf_gem.rbs
@@ -47,7 +47,12 @@ module RBSProtobuf
 
       def message_to_decl: (untyped message, prefix: RBS::Namespace, message_path: untyped, source_code_info: untyped, path: Array[Integer]) -> RBS::AST::Declarations::Class
 
-      def field_type: (untyped field, Hash[String, [RBS::Types::t, RBS::Types::t]] maps) -> [RBS::Types::t, RBS::Types::t]
+      # Returns a pair of types of a field.
+      #
+      # - The first one is the type of the attribute. (read and write)
+      # - The second one is the array of type of additional possibilities for write.
+      #
+      def field_type: (untyped field, Hash[String, [RBS::Types::t, RBS::Types::t]] maps) -> [RBS::Types::t, Array[RBS::Types::t]]
 
       def enum_base_class: () -> RBS::AST::Declarations::Class::Super
 
@@ -57,7 +62,7 @@ module RBSProtobuf
 
       def extension_to_decl: (untyped extension, prefix: RBS::Namespace, source_code_info: untyped, path: Array[Integer]) -> RBS::AST::Declarations::Class
 
-      def add_field: (Array[RBS::AST::Declarations::Class::member] members, name: Symbol, read_type: RBS::Types::t, write_type: RBS::Types::t, comment: RBS::AST::Comment?) -> void
+      def add_field: (Array[RBS::AST::Declarations::Class::member] members, name: Symbol, read_type: RBS::Types::t, write_types: Array[RBS::Types::t], comment: RBS::AST::Comment?) -> void
 
       def service_base_class: () -> RBS::AST::Declarations::Class::Super
 

--- a/test/protobuf_gem_test.rb
+++ b/test/protobuf_gem_test.rb
@@ -424,7 +424,8 @@ class Message < ::Protobuf::Message
   def []: (:t1) -> ::Size
         | (::Symbol) -> untyped
 
-  def []=: (:t1, ::Size | ::Size::values) -> (::Size | ::Size::values)
+  def []=: (:t1, ::Size) -> ::Size
+         | (:t1, ::Size::values) -> ::Size::values
          | (::Symbol, untyped) -> untyped
 end
 RBS
@@ -484,7 +485,8 @@ class Message < ::Protobuf::Message
   def []: (:t1) -> ::Size
         | (::Symbol) -> untyped
 
-  def []=: (:t1, ::Size | ::Size::values) -> (::Size | ::Size::values)
+  def []=: (:t1, ::Size) -> ::Size
+         | (:t1, ::Size::values) -> ::Size::values
          | (::Symbol, untyped) -> untyped
 end
 RBS
@@ -902,7 +904,8 @@ class Account < ::Protobuf::Message
   def []: (:type) -> ::Account::Type
         | (::Symbol) -> untyped
 
-  def []=: (:type, ::Account::Type | ::Account::Type::values) -> (::Account::Type | ::Account::Type::values)
+  def []=: (:type, ::Account::Type) -> ::Account::Type
+         | (:type, ::Account::Type::values) -> ::Account::Type::values
          | (::Symbol, untyped) -> untyped
 end
 RBS

--- a/test/protobuf_gem_test.rb
+++ b/test/protobuf_gem_test.rb
@@ -412,9 +412,10 @@ class Size < ::Protobuf::Enum
 end
 
 class Message < ::Protobuf::Message
-  attr_reader t1(): ::Size
+  attr_accessor t1(): ::Size
 
-  attr_writer t1(): ::Size | ::Size::values
+  def t1=: (::Size::values) -> ::Size::values
+         | ...
 
   def t1!: () -> ::Size?
 
@@ -471,9 +472,10 @@ class Size < ::Protobuf::Enum
 end
 
 class Message < ::Protobuf::Message
-  attr_reader t1(): ::Size
+  attr_accessor t1(): ::Size
 
-  attr_writer t1(): ::Size | ::Size::values
+  def t1=: (::Size::values) -> ::Size::values
+         | ...
 
   def t1!: () -> ::Size?
 
@@ -888,9 +890,10 @@ class Account < ::Protobuf::Message
     BOT: Type
   end
 
-  attr_reader type(): ::Account::Type
+  attr_accessor type(): ::Account::Type
 
-  attr_writer type(): ::Account::Type | ::Account::Type::values
+  def type=: (::Account::Type::values) -> ::Account::Type::values
+           | ...
 
   def type!: () -> ::Account::Type?
 


### PR DESCRIPTION
Use overloads for field write types to make the type signature clean and readable.

Before:

```rbs
attr_reader size(): ::Size

attr_writer size(): ::Size | ::Size::values
```

After

```rbs
attr_accessor size(): ::Size

def size=: (::Size::values) -> ::Size::values
```

Technically, the two types are not equivalent. The new type doesn't allow parameter to be `::Size | ::Size::values`. Not sure if this is critical, and assuming not.