### PR TITLE
Generate helper types and use them

### DIFF
--- a/lib/rbs_protobuf/translator/protobuf_gem.rb
+++ b/lib/rbs_protobuf/translator/protobuf_gem.rb
@@ -125,10 +125,6 @@ module RBSProtobuf
         end.string
       end
 
-      def repeated_field_type(type, wtype = type)
-        FIELD_ARRAY[type, wtype]
-      end
-
       def message_to_decl(message, prefix:, message_path:, source_code_info:, path:)
         class_name = ActiveSupport::Inflector.upcase_first(message.name)
 
@@ -509,7 +505,7 @@ module RBSProtobuf
           type = base_type(field.type)
 
           if field.label == FieldDescriptorProto::Label::LABEL_REPEATED
-            type = repeated_field_type(type)
+            type = FIELD_ARRAY[type]
             [type, [], type]
           else
             [type, [], type]

--- a/lib/rbs_protobuf/translator/protobuf_gem.rb
+++ b/lib/rbs_protobuf/translator/protobuf_gem.rb
@@ -702,6 +702,64 @@ module RBSProtobuf
               location: nil
             )
           end
+
+          enum_instance_type = factory.instance_type(RBS::TypeName.new(name: enum_name.to_sym, namespace: RBS::Namespace.empty))
+          values_type = factory.alias_type(RBS::TypeName.new(name: :values, namespace: RBS::Namespace.empty))
+
+          enum_decl.members << RBS::AST::Declarations::Alias.new(
+            name: TypeName("init"),
+            type_params: [],
+            type: factory.union_type(enum_instance_type, values_type),
+            annotations: [],
+            comment: RBS::AST::Comment.new(string: "The type of `#initialize` parameter.", location: nil),
+            location: nil
+          )
+
+          enum_decl.members << RBS::AST::Declarations::Alias.new(
+            name: TypeName("field_array"),
+            type_params: [],
+            type: FIELD_ARRAY[
+              enum_instance_type,
+              factory.union_type(enum_instance_type, values_type)
+            ],
+            annotations: [],
+            comment: RBS::AST::Comment.new(string: "The type of `repeated` field.", location: nil),
+            location: nil
+          )
+
+          enum_decl.members << RBS::AST::Declarations::Alias.new(
+            name: TypeName("field_hash"),
+            type_params: [RBS::AST::TypeParam.new(name: :KEY, variance: :invariant, upper_bound: nil, location: nil)],
+            type: FIELD_HASH[
+              factory.type_var(:KEY),
+              enum_instance_type,
+              factory.union_type(enum_instance_type, values_type)
+            ],
+            annotations: [],
+            comment: RBS::AST::Comment.new(string: "The type of `map` field.", location: nil),
+            location: nil
+          )
+
+          enum_decl.members << RBS::AST::Declarations::Alias.new(
+            name: TypeName("array"),
+            type_params: [],
+            type: RBS::BuiltinNames::Array.instance_type(factory.union_type(enum_instance_type, values_type)),
+            annotations: [],
+            comment: nil,
+            location: nil
+          )
+
+          enum_decl.members << RBS::AST::Declarations::Alias.new(
+            name: TypeName("hash"),
+            type_params: [RBS::AST::TypeParam.new(name: :KEY, variance: :invariant, upper_bound: nil, location: nil)],
+            type: RBS::BuiltinNames::Hash.instance_type(
+              factory.type_var(:KEY),
+              factory.union_type(enum_instance_type, values_type)
+            ),
+            annotations: [],
+            comment: nil,
+            location: nil
+          )
         end
       end
 

--- a/lib/rbs_protobuf/translator/protobuf_gem.rb
+++ b/lib/rbs_protobuf/translator/protobuf_gem.rb
@@ -11,6 +11,10 @@ module RBSProtobuf
 
       TO_PROTO = Name::Interface.new(TypeName("_ToProto"))
 
+      FIELD_ARRAY_a = Name::Alias.new(TypeName("::Protobuf::field_array"))
+
+      FIELD_HASH_a = Name::Alias.new(TypeName("::Protobuf::field_hash"))
+
       attr_reader :stderr
 
       def initialize(input, upcase_enum:, nested_namespace:, extension:, stderr: STDERR)
@@ -450,9 +454,9 @@ module RBSProtobuf
               ]
 
               [
-                hash_type,
-                [],
-                hash_type
+                FIELD_HASH_a[key_type_r, value_type_r],
+                [RBS::BuiltinNames::Hash.instance_type(key_type_r, value_type_r)],
+                RBS::BuiltinNames::Hash.instance_type(key_type_r, value_type_r)
               ]
             end
           else
@@ -505,8 +509,11 @@ module RBSProtobuf
           type = base_type(field.type)
 
           if field.label == FieldDescriptorProto::Label::LABEL_REPEATED
-            type = FIELD_ARRAY[type]
-            [type, [], type]
+            [
+              FIELD_ARRAY_a[type],
+              [RBS::BuiltinNames::Array.instance_type(type)],
+              RBS::BuiltinNames::Array.instance_type(type)
+            ]
           else
             [type, [], type]
           end

--- a/lib/rbs_protobuf/translator/protobuf_gem.rb
+++ b/lib/rbs_protobuf/translator/protobuf_gem.rb
@@ -141,7 +141,7 @@ module RBSProtobuf
           members: [],
           annotations: []
         ).tap do |class_decl|
-          class_instance_type = factory.instance_type(class_decl.name)
+          class_instance_type = factory.instance_type(RBS::TypeName.new(name: class_decl.name.name, namespace: RBS::Namespace.empty))
 
           maps = {}
 
@@ -298,7 +298,7 @@ module RBSProtobuf
               name: :to_proto,
               types: [
                 factory.method_type(
-                  type: factory.function(factory.instance_type(class_decl.name))
+                  type: factory.function(class_instance_type)
                 )
               ],
               annotations: [],
@@ -308,6 +308,15 @@ module RBSProtobuf
               kind: :instance
             )
           end
+
+          class_decl.members << RBS::AST::Declarations::Alias.new(
+            name: TypeName("init"),
+            type_params: [],
+            type: factory.union_type(class_instance_type, TO_PROTO[]),
+            annotations: [],
+            comment: RBS::AST::Comment.new(string: "The type of `#initialize` parameter.", location: nil),
+            location: nil
+          )
 
           class_decl.members << RBS::AST::Declarations::Alias.new(
             name: TypeName("field_array"),

--- a/lib/rbs_protobuf/translator/protobuf_gem.rb
+++ b/lib/rbs_protobuf/translator/protobuf_gem.rb
@@ -439,7 +439,7 @@ module RBSProtobuf
             value_write_types = value_write_types.map {|type| factory.unwrap_optional(type) }
 
             case value_field.type
-            when FieldDescriptorProto::Type::TYPE_MESSAGE
+            when FieldDescriptorProto::Type::TYPE_MESSAGE, FieldDescriptorProto::Type::TYPE_ENUM
               value_type_r.is_a?(RBS::Types::ClassInstance) or raise
               [
                 message_field_hash_type(value_type_r, key_type_r),
@@ -490,23 +490,19 @@ module RBSProtobuf
         when field.type == FieldDescriptorProto::Type::TYPE_ENUM
           type = message_type(field.type_name)
           enum_namespace = type.name.to_namespace
-
           values = factory.alias_type(RBS::TypeName.new(name: :values, namespace: enum_namespace))
-          wtype = factory.union_type(type, values)
 
           if field.label == FieldDescriptorProto::Label::LABEL_REPEATED
-            type = repeated_field_type(type, wtype)
-
             [
-              type,
-              [],
-              type
+              message_field_array_type(type),
+              [message_array_type(type)],
+              message_array_type(type)
             ]
           else
             [
               type,
               [values],
-              factory.union_type(type, values)
+              message_init_type(type)
             ]
           end
         else

--- a/sig/rbs_protobuf/translator/protobuf_gem.rbs
+++ b/sig/rbs_protobuf/translator/protobuf_gem.rbs
@@ -16,6 +16,12 @@ module RBSProtobuf
       # _ToProto
       TO_PROTO: Name::Interface
 
+      # Protobuf::field_array[T]
+      FIELD_ARRAY_a: Name::Alias
+
+      # Protobuf::field_hash[K, V]
+      FIELD_HASH_a: Name::Alias
+
       attr_reader stderr: IO
 
       def initialize: (

--- a/sig/rbs_protobuf/translator/protobuf_gem.rbs
+++ b/sig/rbs_protobuf/translator/protobuf_gem.rbs
@@ -68,10 +68,6 @@ module RBSProtobuf
       #
       def extension_to_decl: (untyped extension, prefix: RBS::Namespace, source_code_info: untyped, path: Array[Integer]) -> RBS::AST::Declarations::Class
 
-      # Returns `FieldArray` instance type.
-      #
-      def repeated_field_type: (RBS::Types::t `type`, ?RBS::Types::t wtype) -> RBS::Types::ClassInstance
-
       # Returns service class stub.
       #
       def service_to_decl: (untyped service, prefix: RBS::Namespace, source_code_info: untyped, path: Array[Integer]) -> RBS::AST::Declarations::Class

--- a/sig/rbs_protobuf/translator/protobuf_gem.rbs
+++ b/sig/rbs_protobuf/translator/protobuf_gem.rbs
@@ -76,12 +76,13 @@ module RBSProtobuf
       #
       def service_to_decl: (untyped service, prefix: RBS::Namespace, source_code_info: untyped, path: Array[Integer]) -> RBS::AST::Declarations::Class
 
-      # Returns a pair of types of a field.
+      # Returns a triple of types of a field.
       #
       # - The first one is the type of the attribute. (read and write)
       # - The second one is the array of type of additional possibilities for write.
+      # - The last one is the type of `initialize` parameter.
       #
-      def field_type: (untyped field, Hash[String, [RBS::Types::t, RBS::Types::t]] maps) -> [RBS::Types::t, Array[RBS::Types::t]]
+      def field_type: (untyped field, Hash[String, [RBS::Types::t, RBS::Types::t]] maps) -> [RBS::Types::t, Array[RBS::Types::t], RBS::Types::t]
 
       # Returns enum names with respect to `#upcase_enum?`.
       #

--- a/sig/rbs_protobuf/translator/protobuf_gem.rbs
+++ b/sig/rbs_protobuf/translator/protobuf_gem.rbs
@@ -13,6 +13,9 @@ module RBSProtobuf
       # Protobuf::Message
       MESSAGE: Name::Class
 
+      # _ToProto
+      TO_PROTO: Name::Interface
+
       attr_reader stderr: IO
 
       def initialize: (

--- a/sig/rbs_protobuf/translator/protobuf_gem.rbs
+++ b/sig/rbs_protobuf/translator/protobuf_gem.rbs
@@ -82,7 +82,19 @@ module RBSProtobuf
       # - The second one is the array of type of additional possibilities for write.
       # - The last one is the type of `initialize` parameter.
       #
-      def field_type: (untyped field, Hash[String, [RBS::Types::t, RBS::Types::t]] maps) -> [RBS::Types::t, Array[RBS::Types::t], RBS::Types::t]
+      def field_type: (untyped field, Hash[String, [untyped, untyped]] maps) -> [RBS::Types::t, Array[RBS::Types::t], RBS::Types::t]
+
+      def message_to_proto_type: (RBS::Types::ClassInstance) -> RBS::Types::Interface
+
+      def message_array_type: (RBS::Types::ClassInstance) -> RBS::Types::Alias
+
+      def message_field_array_type: (RBS::Types::ClassInstance) -> RBS::Types::Alias
+
+      def message_hash_type: (RBS::Types::ClassInstance, RBS::Types::t key) -> RBS::Types::Alias
+
+      def message_field_hash_type: (RBS::Types::ClassInstance, RBS::Types::t key) -> RBS::Types::Alias
+
+      def message_init_type: (RBS::Types::ClassInstance) -> RBS::Types::Alias
 
       # Returns enum names with respect to `#upcase_enum?`.
       #
@@ -94,6 +106,10 @@ module RBSProtobuf
       # - Overloads for attribute writer with `write_types`
       #
       def add_field: (Array[RBS::AST::Declarations::Class::member] members, name: Symbol, read_type: RBS::Types::t, write_types: Array[RBS::Types::t], comment: RBS::AST::Comment?) -> void
+
+      # Returns true if `write_type` is an _interface type_ or an optional type of _interface type_.
+      #
+      def interface_type?: (RBS::Types::t write_type) -> [RBS::AST::TypeParam, RBS::Types::t]?
 
       def service_base_class: () -> RBS::AST::Declarations::Class::Super
     end

--- a/test/protobuf_gem_test.rb
+++ b/test/protobuf_gem_test.rb
@@ -657,7 +657,7 @@ class Message < ::Protobuf::Message
 
   def t1!: () -> ::Size?
 
-  def initialize: (?t1: ::Size | ::Size::values) -> void
+  def initialize: (?t1: ::Size::init) -> void
 
   def []: (:t1) -> ::Size
         | (::Symbol) -> untyped
@@ -748,7 +748,7 @@ class Message < ::Protobuf::Message
 
   def t1!: () -> ::Size?
 
-  def initialize: (?t1: ::Size | ::Size::values) -> void
+  def initialize: (?t1: ::Size::init) -> void
 
   def []: (:t1) -> ::Size
         | (::Symbol) -> untyped
@@ -832,16 +832,20 @@ class Size < ::Protobuf::Enum
 end
 
 class Message < ::Protobuf::Message
-  attr_accessor t1(): ::Protobuf::Field::FieldArray[::Size, ::Size | ::Size::values]
+  attr_accessor t1(): ::Size::field_array
 
-  def t1!: () -> ::Protobuf::Field::FieldArray[::Size, ::Size | ::Size::values]?
+  def t1=: (::Size::array) -> ::Size::array
+         | ...
 
-  def initialize: (?t1: ::Protobuf::Field::FieldArray[::Size, ::Size | ::Size::values]) -> void
+  def t1!: () -> ::Size::field_array?
 
-  def []: (:t1) -> ::Protobuf::Field::FieldArray[::Size, ::Size | ::Size::values]
+  def initialize: (?t1: ::Size::array) -> void
+
+  def []: (:t1) -> ::Size::field_array
         | (::Symbol) -> untyped
 
-  def []=: (:t1, ::Protobuf::Field::FieldArray[::Size, ::Size | ::Size::values]) -> ::Protobuf::Field::FieldArray[::Size, ::Size | ::Size::values]
+  def []=: (:t1, ::Size::field_array) -> ::Size::field_array
+         | (:t1, ::Size::array) -> ::Size::array
          | (::Symbol, untyped) -> untyped
 
   interface _ToProto
@@ -1155,16 +1159,20 @@ class Foo < ::Protobuf::Enum
 end
 
 class Message < ::Protobuf::Message
-  attr_accessor foos(): ::Protobuf::Field::FieldHash[::String, ::Foo, ::Foo | ::Foo::values]
+  attr_accessor foos(): ::Foo::field_hash[::String]
 
-  def foos!: () -> ::Protobuf::Field::FieldHash[::String, ::Foo, ::Foo | ::Foo::values]?
+  def foos=: (::Foo::hash[::String]) -> ::Foo::hash[::String]
+           | ...
 
-  def initialize: (?foos: ::Protobuf::Field::FieldHash[::String, ::Foo, ::Foo | ::Foo::values]) -> void
+  def foos!: () -> ::Foo::field_hash[::String]?
 
-  def []: (:foos) -> ::Protobuf::Field::FieldHash[::String, ::Foo, ::Foo | ::Foo::values]
+  def initialize: (?foos: ::Foo::hash[::String]) -> void
+
+  def []: (:foos) -> ::Foo::field_hash[::String]
         | (::Symbol) -> untyped
 
-  def []=: (:foos, ::Protobuf::Field::FieldHash[::String, ::Foo, ::Foo | ::Foo::values]) -> ::Protobuf::Field::FieldHash[::String, ::Foo, ::Foo | ::Foo::values]
+  def []=: (:foos, ::Foo::field_hash[::String]) -> ::Foo::field_hash[::String]
+         | (:foos, ::Foo::hash[::String]) -> ::Foo::hash[::String]
          | (::Symbol, untyped) -> untyped
 
   interface _ToProto
@@ -1405,7 +1413,7 @@ class Account < ::Protobuf::Message
 
   def type!: () -> ::Account::Type?
 
-  def initialize: (?type: ::Account::Type | ::Account::Type::values) -> void
+  def initialize: (?type: ::Account::Type::init) -> void
 
   def []: (:type) -> ::Account::Type
         | (::Symbol) -> untyped

--- a/test/protobuf_gem_test.rb
+++ b/test/protobuf_gem_test.rb
@@ -164,16 +164,20 @@ EOP
 
     assert_equal <<RBS, content
 class Message < ::Protobuf::Message
-  attr_accessor name(): ::Protobuf::Field::FieldArray[::String, ::String]
+  attr_accessor name(): ::Protobuf::field_array[::String]
 
-  def name!: () -> ::Protobuf::Field::FieldArray[::String, ::String]?
+  def name=: (::Array[::String]) -> ::Array[::String]
+           | ...
 
-  def initialize: (?name: ::Protobuf::Field::FieldArray[::String, ::String]) -> void
+  def name!: () -> ::Protobuf::field_array[::String]?
 
-  def []: (:name) -> ::Protobuf::Field::FieldArray[::String, ::String]
+  def initialize: (?name: ::Array[::String]) -> void
+
+  def []: (:name) -> ::Protobuf::field_array[::String]
         | (::Symbol) -> untyped
 
-  def []=: (:name, ::Protobuf::Field::FieldArray[::String, ::String]) -> ::Protobuf::Field::FieldArray[::String, ::String]
+  def []=: (:name, ::Protobuf::field_array[::String]) -> ::Protobuf::field_array[::String]
+         | (:name, ::Array[::String]) -> ::Array[::String]
          | (::Symbol, untyped) -> untyped
 
   interface _ToProto
@@ -1060,9 +1064,12 @@ EOP
 
     assert_equal <<RBS, content
 class Message < ::Protobuf::Message
-  attr_accessor numbers(): ::Protobuf::Field::FieldHash[::String, ::Integer, ::Integer]
+  attr_accessor numbers(): ::Protobuf::field_hash[::String, ::Integer]
 
-  def numbers!: () -> ::Protobuf::Field::FieldHash[::String, ::Integer, ::Integer]?
+  def numbers=: (::Hash[::String, ::Integer]) -> ::Hash[::String, ::Integer]
+              | ...
+
+  def numbers!: () -> ::Protobuf::field_hash[::String, ::Integer]?
 
   attr_accessor messages(): ::Message::field_hash[::Integer]
 
@@ -1071,13 +1078,14 @@ class Message < ::Protobuf::Message
 
   def messages!: () -> ::Message::field_hash[::Integer]?
 
-  def initialize: (?numbers: ::Protobuf::Field::FieldHash[::String, ::Integer, ::Integer], ?messages: ::Message::hash[::Integer]) -> void
+  def initialize: (?numbers: ::Hash[::String, ::Integer], ?messages: ::Message::hash[::Integer]) -> void
 
-  def []: (:numbers) -> ::Protobuf::Field::FieldHash[::String, ::Integer, ::Integer]
+  def []: (:numbers) -> ::Protobuf::field_hash[::String, ::Integer]
         | (:messages) -> ::Message::field_hash[::Integer]
         | (::Symbol) -> untyped
 
-  def []=: (:numbers, ::Protobuf::Field::FieldHash[::String, ::Integer, ::Integer]) -> ::Protobuf::Field::FieldHash[::String, ::Integer, ::Integer]
+  def []=: (:numbers, ::Protobuf::field_hash[::String, ::Integer]) -> ::Protobuf::field_hash[::String, ::Integer]
+         | (:numbers, ::Hash[::String, ::Integer]) -> ::Hash[::String, ::Integer]
          | (:messages, ::Message::field_hash[::Integer]) -> ::Message::field_hash[::Integer]
          | (:messages, ::Message::hash[::Integer]) -> ::Message::hash[::Integer]
          | (::Symbol, untyped) -> untyped
@@ -1220,16 +1228,20 @@ EOP
 module Test1
   class Message < ::Protobuf::Message
     class Message2 < ::Protobuf::Message
-      attr_accessor foo(): ::Protobuf::Field::FieldHash[::String, ::String, ::String]
+      attr_accessor foo(): ::Protobuf::field_hash[::String, ::String]
 
-      def foo!: () -> ::Protobuf::Field::FieldHash[::String, ::String, ::String]?
+      def foo=: (::Hash[::String, ::String]) -> ::Hash[::String, ::String]
+              | ...
 
-      def initialize: (?foo: ::Protobuf::Field::FieldHash[::String, ::String, ::String]) -> void
+      def foo!: () -> ::Protobuf::field_hash[::String, ::String]?
 
-      def []: (:foo) -> ::Protobuf::Field::FieldHash[::String, ::String, ::String]
+      def initialize: (?foo: ::Hash[::String, ::String]) -> void
+
+      def []: (:foo) -> ::Protobuf::field_hash[::String, ::String]
             | (::Symbol) -> untyped
 
-      def []=: (:foo, ::Protobuf::Field::FieldHash[::String, ::String, ::String]) -> ::Protobuf::Field::FieldHash[::String, ::String, ::String]
+      def []=: (:foo, ::Protobuf::field_hash[::String, ::String]) -> ::Protobuf::field_hash[::String, ::String]
+             | (:foo, ::Hash[::String, ::String]) -> ::Hash[::String, ::String]
              | (::Symbol, untyped) -> untyped
 
       interface _ToProto

--- a/test/protobuf_gem_test.rb
+++ b/test/protobuf_gem_test.rb
@@ -294,14 +294,18 @@ end
 class Foo < ::Protobuf::Message
   attr_accessor m1(): ::Message?
 
+  def m1=: [M < ::Message::_ToProto] (M?) -> M?
+         | ...
+
   def m1!: () -> ::Message?
 
-  def initialize: (?m1: ::Message?) -> void
+  def initialize: (?m1: ::Message::init?) -> void
 
   def []: (:m1) -> ::Message?
         | (::Symbol) -> untyped
 
   def []=: (:m1, ::Message?) -> ::Message?
+         | [M < ::Message::_ToProto] (:m1, M?) -> M?
          | (::Symbol, untyped) -> untyped
 
   interface _ToProto
@@ -369,14 +373,18 @@ end
 class Foo < ::Protobuf::Message
   attr_accessor m1(): ::Message
 
+  def m1=: [M < ::Message::_ToProto] (M) -> M
+         | ...
+
   def m1!: () -> ::Message?
 
-  def initialize: (?m1: ::Message) -> void
+  def initialize: (?m1: ::Message::init) -> void
 
   def []: (:m1) -> ::Message
         | (::Symbol) -> untyped
 
   def []=: (:m1, ::Message) -> ::Message
+         | [M < ::Message::_ToProto] (:m1, M) -> M
          | (::Symbol, untyped) -> untyped
 
   interface _ToProto
@@ -442,16 +450,20 @@ class Message < ::Protobuf::Message
 end
 
 class Foo < ::Protobuf::Message
-  attr_accessor m1(): ::Protobuf::Field::FieldArray[::Message, ::Message]
+  attr_accessor m1(): ::Message::field_array
 
-  def m1!: () -> ::Protobuf::Field::FieldArray[::Message, ::Message]?
+  def m1=: (::Message::array) -> ::Message::array
+         | ...
 
-  def initialize: (?m1: ::Protobuf::Field::FieldArray[::Message, ::Message]) -> void
+  def m1!: () -> ::Message::field_array?
 
-  def []: (:m1) -> ::Protobuf::Field::FieldArray[::Message, ::Message]
+  def initialize: (?m1: ::Message::array) -> void
+
+  def []: (:m1) -> ::Message::field_array
         | (::Symbol) -> untyped
 
-  def []=: (:m1, ::Protobuf::Field::FieldArray[::Message, ::Message]) -> ::Protobuf::Field::FieldArray[::Message, ::Message]
+  def []=: (:m1, ::Message::field_array) -> ::Message::field_array
+         | (:m1, ::Message::array) -> ::Message::array
          | (::Symbol, untyped) -> untyped
 
   interface _ToProto
@@ -817,9 +829,12 @@ module Foo
 
       attr_accessor replyTo(): ::Foo::Ba_r::Message?
 
+      def replyTo=: [M < ::Foo::Ba_r::Message::_ToProto] (M?) -> M?
+                  | ...
+
       def replyTo!: () -> ::Foo::Ba_r::Message?
 
-      def initialize: (?name: ::String, ?replyTo: ::Foo::Ba_r::Message?) -> void
+      def initialize: (?name: ::String, ?replyTo: ::Foo::Ba_r::Message::init?) -> void
 
       def []: (:name) -> ::String
             | (:replyTo) -> ::Foo::Ba_r::Message?
@@ -827,7 +842,7 @@ module Foo
 
       def []=: (:name, ::String) -> ::String
              | (:replyTo, ::Foo::Ba_r::Message?) -> ::Foo::Ba_r::Message?
-             | (:replyTo, ::Foo::Ba_r::Message::_ToProto?) -> ::Foo::Ba_r::Message::_ToProto?
+             | [M < ::Foo::Ba_r::Message::_ToProto] (:replyTo, M?) -> M?
              | (::Symbol, untyped) -> untyped
 
       interface _ToProto
@@ -980,18 +995,22 @@ class Message < ::Protobuf::Message
 
   def numbers!: () -> ::Protobuf::Field::FieldHash[::String, ::Integer, ::Integer]?
 
-  attr_accessor messages(): ::Protobuf::Field::FieldHash[::Integer, ::Message, ::Message]
+  attr_accessor messages(): ::Message::field_hash[::Integer]
 
-  def messages!: () -> ::Protobuf::Field::FieldHash[::Integer, ::Message, ::Message]?
+  def messages=: (::Message::hash[::Integer]) -> ::Message::hash[::Integer]
+               | ...
 
-  def initialize: (?numbers: ::Protobuf::Field::FieldHash[::String, ::Integer, ::Integer], ?messages: ::Protobuf::Field::FieldHash[::Integer, ::Message, ::Message]) -> void
+  def messages!: () -> ::Message::field_hash[::Integer]?
+
+  def initialize: (?numbers: ::Protobuf::Field::FieldHash[::String, ::Integer, ::Integer], ?messages: ::Message::hash[::Integer]) -> void
 
   def []: (:numbers) -> ::Protobuf::Field::FieldHash[::String, ::Integer, ::Integer]
-        | (:messages) -> ::Protobuf::Field::FieldHash[::Integer, ::Message, ::Message]
+        | (:messages) -> ::Message::field_hash[::Integer]
         | (::Symbol) -> untyped
 
   def []=: (:numbers, ::Protobuf::Field::FieldHash[::String, ::Integer, ::Integer]) -> ::Protobuf::Field::FieldHash[::String, ::Integer, ::Integer]
-         | (:messages, ::Protobuf::Field::FieldHash[::Integer, ::Message, ::Message]) -> ::Protobuf::Field::FieldHash[::Integer, ::Message, ::Message]
+         | (:messages, ::Message::field_hash[::Integer]) -> ::Message::field_hash[::Integer]
+         | (:messages, ::Message::hash[::Integer]) -> ::Message::hash[::Integer]
          | (::Symbol, untyped) -> untyped
 
   interface _ToProto
@@ -1212,14 +1231,18 @@ class M1 < ::Protobuf::Message
 
   attr_accessor m(): ::M1::M2?
 
+  def m=: [M < ::M1::M2::_ToProto] (M?) -> M?
+        | ...
+
   def m!: () -> ::M1::M2?
 
-  def initialize: (?m: ::M1::M2?) -> void
+  def initialize: (?m: ::M1::M2::init?) -> void
 
   def []: (:m) -> ::M1::M2?
         | (::Symbol) -> untyped
 
   def []=: (:m, ::M1::M2?) -> ::M1::M2?
+         | [M < ::M1::M2::_ToProto] (:m, M?) -> M?
          | (::Symbol, untyped) -> untyped
 
   interface _ToProto
@@ -1484,12 +1507,16 @@ end
 class ::Test::M1
   attr_accessor parent(): ::Test::M1?
 
+  def parent=: [M < ::Test::M1::_ToProto] (M?) -> M?
+             | ...
+
   def parent!: () -> ::Test::M1?
 
   def []: (:parent) -> ::Test::M1?
         | ...
 
   def []=: (:parent, ::Test::M1?) -> ::Test::M1?
+         | [M < ::Test::M1::_ToProto] (:parent, M?) -> M?
          | ...
 end
 RBS

--- a/test/protobuf_gem_test.rb
+++ b/test/protobuf_gem_test.rb
@@ -27,6 +27,9 @@ class Message < ::Protobuf::Message
     def to_proto: () -> Message
   end
 
+  # The type of `#initialize` parameter.
+  type init = Message | _ToProto
+
   # The type of `repeated` field.
   type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
 
@@ -74,6 +77,9 @@ class Message < ::Protobuf::Message
   interface _ToProto
     def to_proto: () -> Message
   end
+
+  # The type of `#initialize` parameter.
+  type init = Message | _ToProto
 
   # The type of `repeated` field.
   type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -123,6 +129,9 @@ class Message < ::Protobuf::Message
     def to_proto: () -> Message
   end
 
+  # The type of `#initialize` parameter.
+  type init = Message | _ToProto
+
   # The type of `repeated` field.
   type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
 
@@ -170,6 +179,9 @@ class Message < ::Protobuf::Message
   interface _ToProto
     def to_proto: () -> Message
   end
+
+  # The type of `#initialize` parameter.
+  type init = Message | _ToProto
 
   # The type of `repeated` field.
   type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -221,6 +233,9 @@ class Message < ::Protobuf::Message
     def to_proto: () -> Message
   end
 
+  # The type of `#initialize` parameter.
+  type init = Message | _ToProto
+
   # The type of `repeated` field.
   type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
 
@@ -262,6 +277,9 @@ class Message < ::Protobuf::Message
     def to_proto: () -> Message
   end
 
+  # The type of `#initialize` parameter.
+  type init = Message | _ToProto
+
   # The type of `repeated` field.
   type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
 
@@ -289,6 +307,9 @@ class Foo < ::Protobuf::Message
   interface _ToProto
     def to_proto: () -> Foo
   end
+
+  # The type of `#initialize` parameter.
+  type init = Foo | _ToProto
 
   # The type of `repeated` field.
   type field_array = ::Protobuf::Field::FieldArray[Foo, Foo | _ToProto]
@@ -331,6 +352,9 @@ class Message < ::Protobuf::Message
     def to_proto: () -> Message
   end
 
+  # The type of `#initialize` parameter.
+  type init = Message | _ToProto
+
   # The type of `repeated` field.
   type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
 
@@ -358,6 +382,9 @@ class Foo < ::Protobuf::Message
   interface _ToProto
     def to_proto: () -> Foo
   end
+
+  # The type of `#initialize` parameter.
+  type init = Foo | _ToProto
 
   # The type of `repeated` field.
   type field_array = ::Protobuf::Field::FieldArray[Foo, Foo | _ToProto]
@@ -400,6 +427,9 @@ class Message < ::Protobuf::Message
     def to_proto: () -> Message
   end
 
+  # The type of `#initialize` parameter.
+  type init = Message | _ToProto
+
   # The type of `repeated` field.
   type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
 
@@ -427,6 +457,9 @@ class Foo < ::Protobuf::Message
   interface _ToProto
     def to_proto: () -> Foo
   end
+
+  # The type of `#initialize` parameter.
+  type init = Foo | _ToProto
 
   # The type of `repeated` field.
   type field_array = ::Protobuf::Field::FieldArray[Foo, Foo | _ToProto]
@@ -586,6 +619,9 @@ class Message < ::Protobuf::Message
     def to_proto: () -> Message
   end
 
+  # The type of `#initialize` parameter.
+  type init = Message | _ToProto
+
   # The type of `repeated` field.
   type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
 
@@ -661,6 +697,9 @@ class Message < ::Protobuf::Message
     def to_proto: () -> Message
   end
 
+  # The type of `#initialize` parameter.
+  type init = Message | _ToProto
+
   # The type of `repeated` field.
   type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
 
@@ -732,6 +771,9 @@ class Message < ::Protobuf::Message
     def to_proto: () -> Message
   end
 
+  # The type of `#initialize` parameter.
+  type init = Message | _ToProto
+
   # The type of `repeated` field.
   type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
 
@@ -785,11 +827,15 @@ module Foo
 
       def []=: (:name, ::String) -> ::String
              | (:replyTo, ::Foo::Ba_r::Message?) -> ::Foo::Ba_r::Message?
+             | (:replyTo, ::Foo::Ba_r::Message::_ToProto?) -> ::Foo::Ba_r::Message::_ToProto?
              | (::Symbol, untyped) -> untyped
 
       interface _ToProto
         def to_proto: () -> Message
       end
+
+      # The type of `#initialize` parameter.
+      type init = Message | _ToProto
 
       # The type of `repeated` field.
       type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -829,18 +875,21 @@ class Foo::Ba_r::Message < ::Protobuf::Message
   def initialize: () -> void
 
   interface _ToProto
-    def to_proto: () -> Foo::Ba_r::Message
+    def to_proto: () -> Message
   end
 
+  # The type of `#initialize` parameter.
+  type init = Message | _ToProto
+
   # The type of `repeated` field.
-  type field_array = ::Protobuf::Field::FieldArray[Foo::Ba_r::Message, Foo::Ba_r::Message | _ToProto]
+  type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
 
   # The type of `map` field.
-  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Foo::Ba_r::Message, Foo::Ba_r::Message | _ToProto]
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Message, Message | _ToProto]
 
-  type array = ::Array[Foo::Ba_r::Message | _ToProto]
+  type array = ::Array[Message | _ToProto]
 
-  type hash[KEY] = ::Hash[KEY, Foo::Ba_r::Message | _ToProto]
+  type hash[KEY] = ::Hash[KEY, Message | _ToProto]
 end
 RBS
   end
@@ -890,6 +939,9 @@ class Message < ::Protobuf::Message
   interface _ToProto
     def to_proto: () -> Message
   end
+
+  # The type of `#initialize` parameter.
+  type init = Message | _ToProto
 
   # The type of `repeated` field.
   type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -945,6 +997,9 @@ class Message < ::Protobuf::Message
   interface _ToProto
     def to_proto: () -> Message
   end
+
+  # The type of `#initialize` parameter.
+  type init = Message | _ToProto
 
   # The type of `repeated` field.
   type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -1019,6 +1074,9 @@ class Message < ::Protobuf::Message
     def to_proto: () -> Message
   end
 
+  # The type of `#initialize` parameter.
+  type init = Message | _ToProto
+
   # The type of `repeated` field.
   type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
 
@@ -1073,6 +1131,9 @@ module Test1
         def to_proto: () -> Message2
       end
 
+      # The type of `#initialize` parameter.
+      type init = Message2 | _ToProto
+
       # The type of `repeated` field.
       type field_array = ::Protobuf::Field::FieldArray[Message2, Message2 | _ToProto]
 
@@ -1089,6 +1150,9 @@ module Test1
     interface _ToProto
       def to_proto: () -> Message
     end
+
+    # The type of `#initialize` parameter.
+    type init = Message | _ToProto
 
     # The type of `repeated` field.
     type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -1132,6 +1196,9 @@ class M1 < ::Protobuf::Message
       def to_proto: () -> M2
     end
 
+    # The type of `#initialize` parameter.
+    type init = M2 | _ToProto
+
     # The type of `repeated` field.
     type field_array = ::Protobuf::Field::FieldArray[M2, M2 | _ToProto]
 
@@ -1158,6 +1225,9 @@ class M1 < ::Protobuf::Message
   interface _ToProto
     def to_proto: () -> M1
   end
+
+  # The type of `#initialize` parameter.
+  type init = M1 | _ToProto
 
   # The type of `repeated` field.
   type field_array = ::Protobuf::Field::FieldArray[M1, M1 | _ToProto]
@@ -1234,6 +1304,9 @@ class Account < ::Protobuf::Message
     def to_proto: () -> Account
   end
 
+  # The type of `#initialize` parameter.
+  type init = Account | _ToProto
+
   # The type of `repeated` field.
   type field_array = ::Protobuf::Field::FieldArray[Account, Account | _ToProto]
 
@@ -1282,6 +1355,9 @@ class SearchRequest < ::Protobuf::Message
     def to_proto: () -> SearchRequest
   end
 
+  # The type of `#initialize` parameter.
+  type init = SearchRequest | _ToProto
+
   # The type of `repeated` field.
   type field_array = ::Protobuf::Field::FieldArray[SearchRequest, SearchRequest | _ToProto]
 
@@ -1300,6 +1376,9 @@ class SearchResponse < ::Protobuf::Message
     def to_proto: () -> SearchResponse
   end
 
+  # The type of `#initialize` parameter.
+  type init = SearchResponse | _ToProto
+
   # The type of `repeated` field.
   type field_array = ::Protobuf::Field::FieldArray[SearchResponse, SearchResponse | _ToProto]
 
@@ -1317,6 +1396,9 @@ class Message < ::Protobuf::Message
   interface _ToProto
     def to_proto: () -> Message
   end
+
+  # The type of `#initialize` parameter.
+  type init = Message | _ToProto
 
   # The type of `repeated` field.
   type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -1369,6 +1451,9 @@ module Test
     interface _ToProto
       def to_proto: () -> M1
     end
+
+    # The type of `#initialize` parameter.
+    type init = M1 | _ToProto
 
     # The type of `repeated` field.
     type field_array = ::Protobuf::Field::FieldArray[M1, M1 | _ToProto]
@@ -1444,6 +1529,9 @@ module Test
       def to_proto: () -> M1
     end
 
+    # The type of `#initialize` parameter.
+    type init = M1 | _ToProto
+
     # The type of `repeated` field.
     type field_array = ::Protobuf::Field::FieldArray[M1, M1 | _ToProto]
 
@@ -1494,6 +1582,9 @@ module Test
     interface _ToProto
       def to_proto: () -> M1
     end
+
+    # The type of `#initialize` parameter.
+    type init = M1 | _ToProto
 
     # The type of `repeated` field.
     type field_array = ::Protobuf::Field::FieldArray[M1, M1 | _ToProto]
@@ -1570,6 +1661,9 @@ class Message < ::Protobuf::Message
   interface _ToProto
     def to_proto: () -> Message
   end
+
+  # The type of `#initialize` parameter.
+  type init = Message | _ToProto
 
   # The type of `repeated` field.
   type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]

--- a/test/protobuf_gem_test.rb
+++ b/test/protobuf_gem_test.rb
@@ -22,6 +22,20 @@ EOP
     assert_equal <<RBS, content
 class Message < ::Protobuf::Message
   def initialize: () -> void
+
+  interface _ToProto
+    def to_proto: () -> Message
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Message, Message | _ToProto]
+
+  type array = ::Array[Message | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, Message | _ToProto]
 end
 RBS
   end
@@ -56,6 +70,20 @@ class Message < ::Protobuf::Message
 
   def []=: (:name, ::String) -> ::String
          | (::Symbol, untyped) -> untyped
+
+  interface _ToProto
+    def to_proto: () -> Message
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Message, Message | _ToProto]
+
+  type array = ::Array[Message | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, Message | _ToProto]
 end
 RBS
   end
@@ -90,6 +118,20 @@ class Message < ::Protobuf::Message
 
   def []=: (:name, ::String) -> ::String
          | (::Symbol, untyped) -> untyped
+
+  interface _ToProto
+    def to_proto: () -> Message
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Message, Message | _ToProto]
+
+  type array = ::Array[Message | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, Message | _ToProto]
 end
 RBS
   end
@@ -124,6 +166,20 @@ class Message < ::Protobuf::Message
 
   def []=: (:name, ::Protobuf::Field::FieldArray[::String, ::String]) -> ::Protobuf::Field::FieldArray[::String, ::String]
          | (::Symbol, untyped) -> untyped
+
+  interface _ToProto
+    def to_proto: () -> Message
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Message, Message | _ToProto]
+
+  type array = ::Array[Message | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, Message | _ToProto]
 end
 RBS
   end
@@ -160,6 +216,20 @@ class Message < ::Protobuf::Message
          | (::Symbol, untyped) -> untyped
 
   def name?: () -> bool
+
+  interface _ToProto
+    def to_proto: () -> Message
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Message, Message | _ToProto]
+
+  type array = ::Array[Message | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, Message | _ToProto]
 end
 RBS
   end
@@ -187,6 +257,20 @@ EOP
     assert_equal <<RBS, content
 class Message < ::Protobuf::Message
   def initialize: () -> void
+
+  interface _ToProto
+    def to_proto: () -> Message
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Message, Message | _ToProto]
+
+  type array = ::Array[Message | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, Message | _ToProto]
 end
 
 class Foo < ::Protobuf::Message
@@ -201,6 +285,20 @@ class Foo < ::Protobuf::Message
 
   def []=: (:m1, ::Message?) -> ::Message?
          | (::Symbol, untyped) -> untyped
+
+  interface _ToProto
+    def to_proto: () -> Foo
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Foo, Foo | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Foo, Foo | _ToProto]
+
+  type array = ::Array[Foo | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, Foo | _ToProto]
 end
 RBS
   end
@@ -228,6 +326,20 @@ EOP
     assert_equal <<RBS, content
 class Message < ::Protobuf::Message
   def initialize: () -> void
+
+  interface _ToProto
+    def to_proto: () -> Message
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Message, Message | _ToProto]
+
+  type array = ::Array[Message | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, Message | _ToProto]
 end
 
 class Foo < ::Protobuf::Message
@@ -242,6 +354,20 @@ class Foo < ::Protobuf::Message
 
   def []=: (:m1, ::Message) -> ::Message
          | (::Symbol, untyped) -> untyped
+
+  interface _ToProto
+    def to_proto: () -> Foo
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Foo, Foo | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Foo, Foo | _ToProto]
+
+  type array = ::Array[Foo | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, Foo | _ToProto]
 end
 RBS
   end
@@ -269,6 +395,20 @@ EOP
     assert_equal <<RBS, content
 class Message < ::Protobuf::Message
   def initialize: () -> void
+
+  interface _ToProto
+    def to_proto: () -> Message
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Message, Message | _ToProto]
+
+  type array = ::Array[Message | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, Message | _ToProto]
 end
 
 class Foo < ::Protobuf::Message
@@ -283,6 +423,20 @@ class Foo < ::Protobuf::Message
 
   def []=: (:m1, ::Protobuf::Field::FieldArray[::Message, ::Message]) -> ::Protobuf::Field::FieldArray[::Message, ::Message]
          | (::Symbol, untyped) -> untyped
+
+  interface _ToProto
+    def to_proto: () -> Foo
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Foo, Foo | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Foo, Foo | _ToProto]
+
+  type array = ::Array[Foo | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, Foo | _ToProto]
 end
 RBS
   end
@@ -427,6 +581,20 @@ class Message < ::Protobuf::Message
   def []=: (:t1, ::Size) -> ::Size
          | (:t1, ::Size::values) -> ::Size::values
          | (::Symbol, untyped) -> untyped
+
+  interface _ToProto
+    def to_proto: () -> Message
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Message, Message | _ToProto]
+
+  type array = ::Array[Message | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, Message | _ToProto]
 end
 RBS
   end
@@ -488,6 +656,20 @@ class Message < ::Protobuf::Message
   def []=: (:t1, ::Size) -> ::Size
          | (:t1, ::Size::values) -> ::Size::values
          | (::Symbol, untyped) -> untyped
+
+  interface _ToProto
+    def to_proto: () -> Message
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Message, Message | _ToProto]
+
+  type array = ::Array[Message | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, Message | _ToProto]
 end
 RBS
   end
@@ -545,6 +727,20 @@ class Message < ::Protobuf::Message
 
   def []=: (:t1, ::Protobuf::Field::FieldArray[::Size, ::Size | ::Size::values]) -> ::Protobuf::Field::FieldArray[::Size, ::Size | ::Size::values]
          | (::Symbol, untyped) -> untyped
+
+  interface _ToProto
+    def to_proto: () -> Message
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Message, Message | _ToProto]
+
+  type array = ::Array[Message | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, Message | _ToProto]
 end
 RBS
   end
@@ -590,6 +786,20 @@ module Foo
       def []=: (:name, ::String) -> ::String
              | (:replyTo, ::Foo::Ba_r::Message?) -> ::Foo::Ba_r::Message?
              | (::Symbol, untyped) -> untyped
+
+      interface _ToProto
+        def to_proto: () -> Message
+      end
+
+      # The type of `repeated` field.
+      type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
+
+      # The type of `map` field.
+      type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Message, Message | _ToProto]
+
+      type array = ::Array[Message | _ToProto]
+
+      type hash[KEY] = ::Hash[KEY, Message | _ToProto]
     end
   end
 end
@@ -617,6 +827,20 @@ EOP
     assert_equal <<RBS, content
 class Foo::Ba_r::Message < ::Protobuf::Message
   def initialize: () -> void
+
+  interface _ToProto
+    def to_proto: () -> Foo::Ba_r::Message
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Foo::Ba_r::Message, Foo::Ba_r::Message | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Foo::Ba_r::Message, Foo::Ba_r::Message | _ToProto]
+
+  type array = ::Array[Foo::Ba_r::Message | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, Foo::Ba_r::Message | _ToProto]
 end
 RBS
   end
@@ -662,6 +886,20 @@ class Message < ::Protobuf::Message
   def []=: (:name, ::String) -> ::String
          | (:size, ::Integer) -> ::Integer
          | (::Symbol, untyped) -> untyped
+
+  interface _ToProto
+    def to_proto: () -> Message
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Message, Message | _ToProto]
+
+  type array = ::Array[Message | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, Message | _ToProto]
 end
 RBS
   end
@@ -703,6 +941,20 @@ class Message < ::Protobuf::Message
   def []=: (:numbers, ::Protobuf::Field::FieldHash[::String, ::Integer, ::Integer]) -> ::Protobuf::Field::FieldHash[::String, ::Integer, ::Integer]
          | (:messages, ::Protobuf::Field::FieldHash[::Integer, ::Message, ::Message]) -> ::Protobuf::Field::FieldHash[::Integer, ::Message, ::Message]
          | (::Symbol, untyped) -> untyped
+
+  interface _ToProto
+    def to_proto: () -> Message
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Message, Message | _ToProto]
+
+  type array = ::Array[Message | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, Message | _ToProto]
 end
 RBS
   end
@@ -762,6 +1014,20 @@ class Message < ::Protobuf::Message
 
   def []=: (:foos, ::Protobuf::Field::FieldHash[::String, ::Foo, ::Foo | ::Foo::values]) -> ::Protobuf::Field::FieldHash[::String, ::Foo, ::Foo | ::Foo::values]
          | (::Symbol, untyped) -> untyped
+
+  interface _ToProto
+    def to_proto: () -> Message
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Message, Message | _ToProto]
+
+  type array = ::Array[Message | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, Message | _ToProto]
 end
 RBS
   end
@@ -802,9 +1068,37 @@ module Test1
 
       def []=: (:foo, ::Protobuf::Field::FieldHash[::String, ::String, ::String]) -> ::Protobuf::Field::FieldHash[::String, ::String, ::String]
              | (::Symbol, untyped) -> untyped
+
+      interface _ToProto
+        def to_proto: () -> Message2
+      end
+
+      # The type of `repeated` field.
+      type field_array = ::Protobuf::Field::FieldArray[Message2, Message2 | _ToProto]
+
+      # The type of `map` field.
+      type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Message2, Message2 | _ToProto]
+
+      type array = ::Array[Message2 | _ToProto]
+
+      type hash[KEY] = ::Hash[KEY, Message2 | _ToProto]
     end
 
     def initialize: () -> void
+
+    interface _ToProto
+      def to_proto: () -> Message
+    end
+
+    # The type of `repeated` field.
+    type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
+
+    # The type of `map` field.
+    type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Message, Message | _ToProto]
+
+    type array = ::Array[Message | _ToProto]
+
+    type hash[KEY] = ::Hash[KEY, Message | _ToProto]
   end
 end
 RBS
@@ -833,6 +1127,20 @@ EOP
 class M1 < ::Protobuf::Message
   class M2 < ::Protobuf::Message
     def initialize: () -> void
+
+    interface _ToProto
+      def to_proto: () -> M2
+    end
+
+    # The type of `repeated` field.
+    type field_array = ::Protobuf::Field::FieldArray[M2, M2 | _ToProto]
+
+    # The type of `map` field.
+    type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, M2, M2 | _ToProto]
+
+    type array = ::Array[M2 | _ToProto]
+
+    type hash[KEY] = ::Hash[KEY, M2 | _ToProto]
   end
 
   attr_accessor m(): ::M1::M2?
@@ -846,6 +1154,20 @@ class M1 < ::Protobuf::Message
 
   def []=: (:m, ::M1::M2?) -> ::M1::M2?
          | (::Symbol, untyped) -> untyped
+
+  interface _ToProto
+    def to_proto: () -> M1
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[M1, M1 | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, M1, M1 | _ToProto]
+
+  type array = ::Array[M1 | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, M1 | _ToProto]
 end
 RBS
   end
@@ -907,6 +1229,20 @@ class Account < ::Protobuf::Message
   def []=: (:type, ::Account::Type) -> ::Account::Type
          | (:type, ::Account::Type::values) -> ::Account::Type::values
          | (::Symbol, untyped) -> untyped
+
+  interface _ToProto
+    def to_proto: () -> Account
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Account, Account | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Account, Account | _ToProto]
+
+  type array = ::Array[Account | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, Account | _ToProto]
 end
 RBS
   end
@@ -941,14 +1277,56 @@ EOP
     assert_equal <<RBS, content
 class SearchRequest < ::Protobuf::Message
   def initialize: () -> void
+
+  interface _ToProto
+    def to_proto: () -> SearchRequest
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[SearchRequest, SearchRequest | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, SearchRequest, SearchRequest | _ToProto]
+
+  type array = ::Array[SearchRequest | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, SearchRequest | _ToProto]
 end
 
 class SearchResponse < ::Protobuf::Message
   def initialize: () -> void
+
+  interface _ToProto
+    def to_proto: () -> SearchResponse
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[SearchResponse, SearchResponse | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, SearchResponse, SearchResponse | _ToProto]
+
+  type array = ::Array[SearchResponse | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, SearchResponse | _ToProto]
 end
 
 class Message < ::Protobuf::Message
   def initialize: () -> void
+
+  interface _ToProto
+    def to_proto: () -> Message
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Message, Message | _ToProto]
+
+  type array = ::Array[Message | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, Message | _ToProto]
 end
 
 class SearchService < ::Protobuf::Rpc::Service
@@ -987,6 +1365,20 @@ EOP
 module Test
   class M1 < ::Protobuf::Message
     def initialize: () -> void
+
+    interface _ToProto
+      def to_proto: () -> M1
+    end
+
+    # The type of `repeated` field.
+    type field_array = ::Protobuf::Field::FieldArray[M1, M1 | _ToProto]
+
+    # The type of `map` field.
+    type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, M1, M1 | _ToProto]
+
+    type array = ::Array[M1 | _ToProto]
+
+    type hash[KEY] = ::Hash[KEY, M1 | _ToProto]
   end
 end
 
@@ -1047,6 +1439,20 @@ EOP
 module Test
   class M1 < ::Protobuf::Message
     def initialize: () -> void
+
+    interface _ToProto
+      def to_proto: () -> M1
+    end
+
+    # The type of `repeated` field.
+    type field_array = ::Protobuf::Field::FieldArray[M1, M1 | _ToProto]
+
+    # The type of `map` field.
+    type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, M1, M1 | _ToProto]
+
+    type array = ::Array[M1 | _ToProto]
+
+    type hash[KEY] = ::Hash[KEY, M1 | _ToProto]
   end
 end
 RBS
@@ -1084,6 +1490,20 @@ EOP
 module Test
   class M1 < ::Protobuf::Message
     def initialize: () -> void
+
+    interface _ToProto
+      def to_proto: () -> M1
+    end
+
+    # The type of `repeated` field.
+    type field_array = ::Protobuf::Field::FieldArray[M1, M1 | _ToProto]
+
+    # The type of `map` field.
+    type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, M1, M1 | _ToProto]
+
+    type array = ::Array[M1 | _ToProto]
+
+    type hash[KEY] = ::Hash[KEY, M1 | _ToProto]
   end
 end
 RBS
@@ -1146,6 +1566,20 @@ class Message < ::Protobuf::Message
 
   def []=: (:name, ::String) -> ::String
          | (::Symbol, untyped) -> untyped
+
+  interface _ToProto
+    def to_proto: () -> Message
+  end
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Message, Message | _ToProto]
+
+  type array = ::Array[Message | _ToProto]
+
+  type hash[KEY] = ::Hash[KEY, Message | _ToProto]
 end
 RBS
   end

--- a/test/protobuf_gem_test.rb
+++ b/test/protobuf_gem_test.rb
@@ -521,6 +521,19 @@ class Type < ::Protobuf::Enum
   Foo: Type
 
   BAR: Type
+
+  # The type of `#initialize` parameter.
+  type init = Type | values
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Type, Type | values]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Type, Type | values]
+
+  type array = ::Array[Type | values]
+
+  type hash[KEY] = ::Hash[KEY, Type | values]
 end
 RBS
   end
@@ -565,6 +578,19 @@ class Type < ::Protobuf::Enum
   Foo: Type
 
   BAR: Type
+
+  # The type of `#initialize` parameter.
+  type init = Type | values
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Type, Type | values]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Type, Type | values]
+
+  type array = ::Array[Type | values]
+
+  type hash[KEY] = ::Hash[KEY, Type | values]
 end
 RBS
   end
@@ -608,6 +634,19 @@ class Size < ::Protobuf::Enum
   SMALL: Size
 
   LARGE: Size
+
+  # The type of `#initialize` parameter.
+  type init = Size | values
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Size, Size | values]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Size, Size | values]
+
+  type array = ::Array[Size | values]
+
+  type hash[KEY] = ::Hash[KEY, Size | values]
 end
 
 class Message < ::Protobuf::Message
@@ -686,6 +725,19 @@ class Size < ::Protobuf::Enum
   SMALL: Size
 
   LARGE: Size
+
+  # The type of `#initialize` parameter.
+  type init = Size | values
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Size, Size | values]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Size, Size | values]
+
+  type array = ::Array[Size | values]
+
+  type hash[KEY] = ::Hash[KEY, Size | values]
 end
 
 class Message < ::Protobuf::Message
@@ -764,6 +816,19 @@ class Size < ::Protobuf::Enum
   SMALL: Size
 
   LARGE: Size
+
+  # The type of `#initialize` parameter.
+  type init = Size | values
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Size, Size | values]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Size, Size | values]
+
+  type array = ::Array[Size | values]
+
+  type hash[KEY] = ::Hash[KEY, Size | values]
 end
 
 class Message < ::Protobuf::Message
@@ -1074,6 +1139,19 @@ class Foo < ::Protobuf::Enum
   BAR: Foo
 
   BAZ: Foo
+
+  # The type of `#initialize` parameter.
+  type init = Foo | values
+
+  # The type of `repeated` field.
+  type field_array = ::Protobuf::Field::FieldArray[Foo, Foo | values]
+
+  # The type of `map` field.
+  type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Foo, Foo | values]
+
+  type array = ::Array[Foo | values]
+
+  type hash[KEY] = ::Hash[KEY, Foo | values]
 end
 
 class Message < ::Protobuf::Message
@@ -1305,6 +1383,19 @@ class Account < ::Protobuf::Message
     HUMAN: Type
 
     BOT: Type
+
+    # The type of `#initialize` parameter.
+    type init = Type | values
+
+    # The type of `repeated` field.
+    type field_array = ::Protobuf::Field::FieldArray[Type, Type | values]
+
+    # The type of `map` field.
+    type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Type, Type | values]
+
+    type array = ::Array[Type | values]
+
+    type hash[KEY] = ::Hash[KEY, Type | values]
   end
 
   attr_accessor type(): ::Account::Type


### PR DESCRIPTION
Add several _helper_ types and use it to keep the generated type definitions clean.

It generates the following helper types for message `M` and enum `E`.

* `M::_ToProto`: An interface with `#to_proto` method
* `M::init`, `E::init`: A type of `#initialize` parameter
* `M::field_array`, `E::field_array`: `Protobuf::Field::FieldArray` type with the message/enum
* `M::field_hash[K]`, `E::field_hash[K]`: `Protobuf::Field::FieldHash` type with the message/enum
* `M::array`, `E::array`: `Array` type which can be used as _write_ types.
* `M::hash[K]`, `E::hash[K]`: `Hash` type which can be used as _write_ types.

It also assumes `Protobuf::field_array` and `Protobuf::field_hash` types introduced in https://github.com/ruby/gem_rbs_collection/pull/145.