### PR TITLE
Support optional fields in proto3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,8 @@ namespace :example do
       "-I#{proto_path}",
       "example/a.proto",
       "example/b.proto",
-      "example/c.proto"
+      "example/c.proto",
+      "example/d.proto"
     )
     sh(
       { "RBS_PROTOBUF_BACKEND" => "protobuf", "RBS_PROTOBUF_EXTENSION" => "true" },
@@ -35,7 +36,8 @@ namespace :example do
       "--rbs_out=example/protobuf-gem",
       "-Iexample",
       "example/a.proto",
-      "example/b.proto"
+      "example/b.proto",
+      "example/d.proto"
     )
     sh(
       { "RBS_PROTOBUF_BACKEND" => "protobuf", "RBS_PROTOBUF_EXTENSION" => "true", "RUBYOPT" => "-rbundler/setup -Iexample/protobuf-gem -rc.pb" },

--- a/bin/protoc-gen-dumper
+++ b/bin/protoc-gen-dumper
@@ -7,5 +7,7 @@ require "rbs_protobuf"
 input = STDIN.read()
 File.write(ENV["PROTOC_DUMPER_OUT"] || "a.pb.out", input)
 
-response = Google::Protobuf::Compiler::CodeGeneratorResponse.new
+response = Google::Protobuf::Compiler::CodeGeneratorResponse.new(
+  :supported_features => ::Google::Protobuf::Compiler::CodeGeneratorResponse::Feature::FEATURE_PROTO3_OPTIONAL.to_i
+)
 print Google::Protobuf::Compiler::CodeGeneratorResponse.encode(response)

--- a/example/d.proto
+++ b/example/d.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+message Foo {
+  string bar = 2;
+  optional string baz = 1;
+}

--- a/lib/rbs_protobuf/translator/base.rb
+++ b/lib/rbs_protobuf/translator/base.rb
@@ -14,7 +14,7 @@ module RBSProtobuf
       end
 
       def response
-        @response ||= Google::Protobuf::Compiler::CodeGeneratorResponse.new
+        @response ||= Google::Protobuf::Compiler::CodeGeneratorResponse.new(:supported_features => ::Google::Protobuf::Compiler::CodeGeneratorResponse::Feature::FEATURE_PROTO3_OPTIONAL.to_i)
       end
 
       def generate_rbs!

--- a/test/protobuf_gem_test.rb
+++ b/test/protobuf_gem_test.rb
@@ -2307,4 +2307,71 @@ class Message < ::Protobuf::Message
 end
 RBS
   end
+
+  def test_proto3_message_optional_field
+    input = read_proto(<<~PROTO)
+      syntax = "proto3";
+
+      message Foo {
+        string bar = 1;
+        optional string baz = 2;
+      }
+    PROTO
+
+    translator = RBSProtobuf::Translator::ProtobufGem.new(
+      input,
+      upcase_enum: true,
+      nested_namespace: true,
+      extension: false,
+      accept_nil_writer: true
+    )
+    content = translator.rbs_content(input.proto_file[0])
+
+    assert_equal <<~RBS, content
+      class Foo < ::Protobuf::Message
+        attr_accessor bar(): ::String
+
+        def bar=: (::String?) -> ::String?
+                | ...
+
+        def bar!: () -> ::String?
+
+        attr_accessor baz(): ::String
+
+        def baz=: (::String?) -> ::String?
+                | ...
+
+        def baz!: () -> ::String?
+
+        def initialize: (?bar: ::String?, ?baz: ::String?) -> void
+
+        def []: (:bar) -> ::String
+              | (:baz) -> ::String
+              | (::Symbol) -> untyped
+
+        def []=: (:bar, ::String) -> ::String
+               | (:bar, ::String?) -> ::String?
+               | (:baz, ::String) -> ::String
+               | (:baz, ::String?) -> ::String?
+               | (::Symbol, untyped) -> untyped
+
+        interface _ToProto
+          def to_proto: () -> Foo
+        end
+
+        # The type of `#initialize` parameter.
+        type init = Foo | _ToProto
+
+        # The type of `repeated` field.
+        type field_array = ::Protobuf::Field::FieldArray[Foo, Foo | _ToProto]
+
+        # The type of `map` field.
+        type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, Foo, Foo | _ToProto]
+
+        type array = ::Array[Foo | _ToProto]
+
+        type hash[KEY] = ::Hash[KEY, Foo | _ToProto]
+      end
+    RBS
+  end
 end


### PR DESCRIPTION
It printed an error message:

```
a.proto: is a proto3 file that contains optional fields, but code generator protoc-gen-rbs hasn't been updated to support optional fields in proto3. Please ask the owner of this code generator to support proto3 optional.--rbs_out: 
```