### PR TITLE
Add `record` type

### DIFF
--- a/lib/rbs_protobuf/rbs_factory.rb
+++ b/lib/rbs_protobuf/rbs_factory.rb
@@ -46,6 +46,7 @@ module RBSProtobuf
     end
 
     def union_type(type, *types)
+      types = types.compact
       if types.empty?
         type
       else

--- a/lib/rbs_protobuf/translator/base.rb
+++ b/lib/rbs_protobuf/translator/base.rb
@@ -128,6 +128,15 @@ module RBSProtobuf
           )
         )
       end
+
+      def optional_type(type)
+        case type
+        when RBS::Types::Optional
+          type
+        else
+          RBS::Types::Optional.new(type: type, location: nil)
+        end
+      end
     end
   end
 end

--- a/lib/rbs_protobuf/translator/protobuf_gem.rb
+++ b/lib/rbs_protobuf/translator/protobuf_gem.rb
@@ -403,6 +403,18 @@ module RBSProtobuf
             comment: nil,
             location: nil
           )
+
+          class_decl.members << RBS::AST::Declarations::TypeAlias.new(
+            name: TypeName("record"),
+            type_params: [],
+            type: RBS::Types::Record.new(
+              fields: field_types.transform_values {|_, _, type| optional_type(type) },
+              location: nil
+              ),
+            annotations: [],
+            location: nil,
+            comment: nil
+          )
         end
       end
 

--- a/lib/rbs_protobuf/translator/protobuf_gem.rb
+++ b/lib/rbs_protobuf/translator/protobuf_gem.rb
@@ -200,7 +200,17 @@ module RBSProtobuf
                 ),
                 annotations: []
               ),
-            ],
+              unless field_types.empty?
+                RBS::AST::Members::MethodDefinition::Overload.new(
+                  method_type: factory.method_type(
+                    type: factory.function().update(
+                      required_positionals: [factory.param(factory.alias_type("record"))]
+                    )
+                  ),
+                  annotations: []
+                )
+              end,
+            ].compact,
             annotations: [],
             comment: nil,
             location: nil,
@@ -352,7 +362,11 @@ module RBSProtobuf
           class_decl.members << RBS::AST::Declarations::TypeAlias.new(
             name: TypeName("init"),
             type_params: [],
-            type: factory.union_type(class_instance_type, TO_PROTO[]),
+            type: factory.union_type(
+              class_instance_type,
+              TO_PROTO[],
+              field_types.empty? ? nil : factory.alias_type("record")
+            ),
             annotations: [],
             comment: RBS::AST::Comment.new(string: "The type of `#initialize` parameter.", location: nil),
             location: nil

--- a/sig/rbs_protobuf/rbs_factory.rbs
+++ b/sig/rbs_protobuf/rbs_factory.rbs
@@ -10,7 +10,7 @@ module RBSProtobuf
 
     def singleton_type: (String | RBS::TypeName name) -> RBS::Types::ClassSingleton
 
-    def union_type: (RBS::Types::t `type`, *RBS::Types::t types) -> RBS::Types::t
+    def union_type: (RBS::Types::t `type`, *RBS::Types::t? types) -> RBS::Types::t
 
     def nil_type: (?location: RBS::Location[untyped, untyped]?) -> RBS::Types::Bases::Nil
 

--- a/sig/rbs_protobuf/translator/base.rbs
+++ b/sig/rbs_protobuf/translator/base.rbs
@@ -36,6 +36,8 @@ module RBSProtobuf
       def base_type: (untyped `type`) -> RBS::Types::t
 
       def message_type: (String) -> RBS::Types::ClassInstance
+
+      def optional_type: (RBS::Types::t) -> RBS::Types::Optional
     end
   end
 end

--- a/test/protobuf_gem_test.rb
+++ b/test/protobuf_gem_test.rb
@@ -40,6 +40,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+        type record = { }
       end
     RBS
   end
@@ -92,6 +94,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+        type record = { name: ::String? }
       end
     RBS
   end
@@ -144,6 +148,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+        type record = { name: ::String? }
       end
     RBS
   end
@@ -200,6 +206,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+        type record = { name: ::Array[::String]? }
       end
     RBS
   end
@@ -254,6 +262,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+        type record = { name: bool? }
       end
     RBS
   end
@@ -299,6 +309,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+        type record = { }
       end
 
       class Foo < ::Protobuf::Message
@@ -334,6 +346,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Foo | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Foo | _ToProto]
+
+        type record = { :m1 => ::Message::init? }
       end
     RBS
   end
@@ -379,6 +393,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+        type record = { }
       end
 
       class Foo < ::Protobuf::Message
@@ -414,6 +430,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Foo | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Foo | _ToProto]
+
+        type record = { :m1 => ::Message::init? }
       end
     RBS
   end
@@ -459,6 +477,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+        type record = { }
       end
 
       class Foo < ::Protobuf::Message
@@ -494,6 +514,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Foo | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Foo | _ToProto]
+
+        type record = { :m1 => ::Message::array? }
       end
     RBS
   end
@@ -697,6 +719,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+        type record = { :t1 => ::Size::init? }
       end
     RBS
   end
@@ -789,6 +813,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+        type record = { :t1 => ::Size::init? }
       end
     RBS
   end
@@ -881,6 +907,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+        type record = { :t1 => ::Size::array? }
       end
     RBS
   end
@@ -948,6 +976,8 @@ class ProtobufGemTest < Minitest::Test
             type array = ::Array[Message | _ToProto]
 
             type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+            type record = { name: ::String?, replyTo: ::Foo::Ba_r::Message::init? }
           end
         end
       end
@@ -993,6 +1023,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+        type record = { }
       end
     RBS
   end
@@ -1056,6 +1088,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+        type record = { name: ::String?, size: ::Integer? }
       end
     RBS
   end
@@ -1123,6 +1157,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+        type record = { numbers: ::Hash[::String, ::Integer]?, messages: ::Message::hash[::Integer]? }
       end
     RBS
   end
@@ -1217,6 +1253,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+        type record = { foos: ::Foo::hash[::String]? }
       end
     RBS
   end
@@ -1279,6 +1317,8 @@ class ProtobufGemTest < Minitest::Test
             type array = ::Array[Message2 | _ToProto]
 
             type hash[KEY] = ::Hash[KEY, Message2 | _ToProto]
+
+            type record = { foo: ::Hash[::String, ::String]? }
           end
 
           def initialize: () -> void
@@ -1299,6 +1339,8 @@ class ProtobufGemTest < Minitest::Test
           type array = ::Array[Message | _ToProto]
 
           type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+          type record = { }
         end
       end
     RBS
@@ -1345,6 +1387,8 @@ class ProtobufGemTest < Minitest::Test
           type array = ::Array[M2 | _ToProto]
 
           type hash[KEY] = ::Hash[KEY, M2 | _ToProto]
+
+          type record = { }
         end
 
         attr_accessor m(): ::M1::M2?
@@ -1379,6 +1423,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[M1 | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, M1 | _ToProto]
+
+        type record = { m: ::M1::M2::init? }
       end
     RBS
   end
@@ -1471,6 +1517,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Account | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Account | _ToProto]
+
+        type record = { type: ::Account::Type::init? }
       end
     RBS
   end
@@ -1523,6 +1571,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[SearchRequest | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, SearchRequest | _ToProto]
+
+        type record = { }
       end
 
       class SearchResponse < ::Protobuf::Message
@@ -1544,6 +1594,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[SearchResponse | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, SearchResponse | _ToProto]
+
+        type record = { }
       end
 
       class Message < ::Protobuf::Message
@@ -1565,6 +1617,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+        type record = { }
       end
 
       class SearchService < ::Protobuf::Rpc::Service
@@ -1621,6 +1675,8 @@ class ProtobufGemTest < Minitest::Test
           type array = ::Array[M1 | _ToProto]
 
           type hash[KEY] = ::Hash[KEY, M1 | _ToProto]
+
+          type record = { }
         end
       end
 
@@ -1703,6 +1759,8 @@ class ProtobufGemTest < Minitest::Test
           type array = ::Array[M1 | _ToProto]
 
           type hash[KEY] = ::Hash[KEY, M1 | _ToProto]
+
+          type record = { }
         end
       end
     RBS
@@ -1758,6 +1816,8 @@ class ProtobufGemTest < Minitest::Test
           type array = ::Array[M1 | _ToProto]
 
           type hash[KEY] = ::Hash[KEY, M1 | _ToProto]
+
+          type record = { }
         end
       end
     RBS
@@ -1838,6 +1898,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+        type record = { name: ::String? }
       end
     RBS
   end
@@ -1894,6 +1956,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+        type record = { name: ::String? }
       end
     RBS
   end
@@ -1952,6 +2016,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+        type record = { name: ::Array[::String]? }
       end
     RBS
   end
@@ -1997,6 +2063,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+        type record = { }
       end
 
       class Foo < ::Protobuf::Message
@@ -2034,6 +2102,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Foo | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Foo | _ToProto]
+
+        type record = { :m1 => ::Message::init? }
       end
     RBS
   end
@@ -2079,6 +2149,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+        type record = { }
       end
 
       class Foo < ::Protobuf::Message
@@ -2116,6 +2188,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Foo | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Foo | _ToProto]
+
+        type record = { :m1 => ::Message::array? }
       end
     RBS
   end
@@ -2210,6 +2284,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+        type record = { :t1 => ::Size::init? }
       end
     RBS
   end
@@ -2304,6 +2380,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
+
+        type record = { :t1 => ::Size::array? }
       end
     RBS
   end
@@ -2371,6 +2449,8 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Foo | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Foo | _ToProto]
+
+        type record = { bar: ::String?, baz: ::String? }
       end
     RBS
   end
@@ -2467,6 +2547,8 @@ class ProtobufGemTest < Minitest::Test
           type array = ::Array[Foo | _ToProto]
 
           type hash[KEY] = ::Hash[KEY, Foo | _ToProto]
+
+          type record = { bar: ::String?, baz: ::String? }
         end
       end
     RBS

--- a/test/protobuf_gem_test.rb
+++ b/test/protobuf_gem_test.rb
@@ -71,6 +71,7 @@ class ProtobufGemTest < Minitest::Test
         def name!: () -> ::String?
 
         def initialize: (?name: ::String) -> void
+                      | (record) -> void
 
         def []: (:name) -> ::String
               | (::Symbol) -> untyped
@@ -83,7 +84,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto
+        type init = Message | _ToProto | record
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -125,6 +126,7 @@ class ProtobufGemTest < Minitest::Test
         def name!: () -> ::String?
 
         def initialize: (?name: ::String) -> void
+                      | (record) -> void
 
         def []: (:name) -> ::String
               | (::Symbol) -> untyped
@@ -137,7 +139,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto
+        type init = Message | _ToProto | record
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -182,6 +184,7 @@ class ProtobufGemTest < Minitest::Test
         def name!: () -> ::Protobuf::field_array[::String]?
 
         def initialize: (?name: ::Array[::String]) -> void
+                      | (record) -> void
 
         def []: (:name) -> ::Protobuf::field_array[::String]
               | (::Symbol) -> untyped
@@ -195,7 +198,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto
+        type init = Message | _ToProto | record
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -237,6 +240,7 @@ class ProtobufGemTest < Minitest::Test
         def name!: () -> bool?
 
         def initialize: (?name: bool) -> void
+                      | (record) -> void
 
         def []: (:name) -> bool
               | (::Symbol) -> untyped
@@ -251,7 +255,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto
+        type init = Message | _ToProto | record
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -322,6 +326,7 @@ class ProtobufGemTest < Minitest::Test
         def m1!: () -> ::Message?
 
         def initialize: (?m1: ::Message::init?) -> void
+                      | (record) -> void
 
         def []: (:m1) -> ::Message?
               | (::Symbol) -> untyped
@@ -335,7 +340,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Foo | _ToProto
+        type init = Foo | _ToProto | record
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Foo, Foo | _ToProto]
@@ -406,6 +411,7 @@ class ProtobufGemTest < Minitest::Test
         def m1!: () -> ::Message?
 
         def initialize: (?m1: ::Message::init) -> void
+                      | (record) -> void
 
         def []: (:m1) -> ::Message
               | (::Symbol) -> untyped
@@ -419,7 +425,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Foo | _ToProto
+        type init = Foo | _ToProto | record
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Foo, Foo | _ToProto]
@@ -490,6 +496,7 @@ class ProtobufGemTest < Minitest::Test
         def m1!: () -> ::Message::field_array?
 
         def initialize: (?m1: ::Message::array) -> void
+                      | (record) -> void
 
         def []: (:m1) -> ::Message::field_array
               | (::Symbol) -> untyped
@@ -503,7 +510,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Foo | _ToProto
+        type init = Foo | _ToProto | record
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Foo, Foo | _ToProto]
@@ -695,6 +702,7 @@ class ProtobufGemTest < Minitest::Test
         def t1!: () -> ::Size?
 
         def initialize: (?t1: ::Size::init) -> void
+                      | (record) -> void
 
         def []: (:t1) -> ::Size
               | (::Symbol) -> untyped
@@ -708,7 +716,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto
+        type init = Message | _ToProto | record
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -789,6 +797,7 @@ class ProtobufGemTest < Minitest::Test
         def t1!: () -> ::Size?
 
         def initialize: (?t1: ::Size::init) -> void
+                      | (record) -> void
 
         def []: (:t1) -> ::Size
               | (::Symbol) -> untyped
@@ -802,7 +811,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto
+        type init = Message | _ToProto | record
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -883,6 +892,7 @@ class ProtobufGemTest < Minitest::Test
         def t1!: () -> ::Size::field_array?
 
         def initialize: (?t1: ::Size::array) -> void
+                      | (record) -> void
 
         def []: (:t1) -> ::Size::field_array
               | (::Symbol) -> untyped
@@ -896,7 +906,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto
+        type init = Message | _ToProto | record
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -950,6 +960,7 @@ class ProtobufGemTest < Minitest::Test
             def replyTo!: () -> ::Foo::Ba_r::Message?
 
             def initialize: (?name: ::String, ?replyTo: ::Foo::Ba_r::Message::init?) -> void
+                          | (record) -> void
 
             def []: (:name) -> ::String
                   | (:replyTo) -> ::Foo::Ba_r::Message?
@@ -965,7 +976,7 @@ class ProtobufGemTest < Minitest::Test
             end
 
             # The type of `#initialize` parameter.
-            type init = Message | _ToProto
+            type init = Message | _ToProto | record
 
             # The type of `repeated` field.
             type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -1063,6 +1074,7 @@ class ProtobufGemTest < Minitest::Test
         def size!: () -> ::Integer?
 
         def initialize: (?name: ::String, ?size: ::Integer) -> void
+                      | (record) -> void
 
         def []: (:name) -> ::String
               | (:size) -> ::Integer
@@ -1077,7 +1089,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto
+        type init = Message | _ToProto | record
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -1130,6 +1142,7 @@ class ProtobufGemTest < Minitest::Test
         def messages!: () -> ::Message::field_hash[::Integer]?
 
         def initialize: (?numbers: ::Hash[::String, ::Integer], ?messages: ::Message::hash[::Integer]) -> void
+                      | (record) -> void
 
         def []: (:numbers) -> ::Protobuf::field_hash[::String, ::Integer]
               | (:messages) -> ::Message::field_hash[::Integer]
@@ -1146,7 +1159,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto
+        type init = Message | _ToProto | record
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -1229,6 +1242,7 @@ class ProtobufGemTest < Minitest::Test
         def foos!: () -> ::Foo::field_hash[::String]?
 
         def initialize: (?foos: ::Foo::hash[::String]) -> void
+                      | (record) -> void
 
         def []: (:foos) -> ::Foo::field_hash[::String]
               | (::Symbol) -> untyped
@@ -1242,7 +1256,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto
+        type init = Message | _ToProto | record
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -1293,6 +1307,7 @@ class ProtobufGemTest < Minitest::Test
             def foo!: () -> ::Protobuf::field_hash[::String, ::String]?
 
             def initialize: (?foo: ::Hash[::String, ::String]) -> void
+                          | (record) -> void
 
             def []: (:foo) -> ::Protobuf::field_hash[::String, ::String]
                   | (::Symbol) -> untyped
@@ -1306,7 +1321,7 @@ class ProtobufGemTest < Minitest::Test
             end
 
             # The type of `#initialize` parameter.
-            type init = Message2 | _ToProto
+            type init = Message2 | _ToProto | record
 
             # The type of `repeated` field.
             type field_array = ::Protobuf::Field::FieldArray[Message2, Message2 | _ToProto]
@@ -1399,6 +1414,7 @@ class ProtobufGemTest < Minitest::Test
         def m!: () -> ::M1::M2?
 
         def initialize: (?m: ::M1::M2::init?) -> void
+                      | (record) -> void
 
         def []: (:m) -> ::M1::M2?
               | (::Symbol) -> untyped
@@ -1412,7 +1428,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = M1 | _ToProto
+        type init = M1 | _ToProto | record
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[M1, M1 | _ToProto]
@@ -1493,6 +1509,7 @@ class ProtobufGemTest < Minitest::Test
         def type!: () -> ::Account::Type?
 
         def initialize: (?type: ::Account::Type::init) -> void
+                      | (record) -> void
 
         def []: (:type) -> ::Account::Type
               | (::Symbol) -> untyped
@@ -1506,7 +1523,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Account | _ToProto
+        type init = Account | _ToProto | record
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Account, Account | _ToProto]
@@ -1875,6 +1892,7 @@ class ProtobufGemTest < Minitest::Test
         def name!: () -> ::String?
 
         def initialize: (?name: ::String) -> void
+                      | (record) -> void
 
         def []: (:name) -> ::String
               | (::Symbol) -> untyped
@@ -1887,7 +1905,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto
+        type init = Message | _ToProto | record
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -1932,6 +1950,7 @@ class ProtobufGemTest < Minitest::Test
         def name!: () -> ::String?
 
         def initialize: (?name: ::String?) -> void
+                      | (record) -> void
 
         def []: (:name) -> ::String
               | (::Symbol) -> untyped
@@ -1945,7 +1964,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto
+        type init = Message | _ToProto | record
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -1991,6 +2010,7 @@ class ProtobufGemTest < Minitest::Test
         def name!: () -> ::Protobuf::field_array[::String]?
 
         def initialize: (?name: ::Array[::String]?) -> void
+                      | (record) -> void
 
         def []: (:name) -> ::Protobuf::field_array[::String]
               | (::Symbol) -> untyped
@@ -2005,7 +2025,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto
+        type init = Message | _ToProto | record
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -2077,6 +2097,7 @@ class ProtobufGemTest < Minitest::Test
         def m1!: () -> ::Message?
 
         def initialize: (?m1: ::Message::init?) -> void
+                      | (record) -> void
 
         def []: (:m1) -> ::Message
               | (::Symbol) -> untyped
@@ -2091,7 +2112,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Foo | _ToProto
+        type init = Foo | _ToProto | record
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Foo, Foo | _ToProto]
@@ -2163,6 +2184,7 @@ class ProtobufGemTest < Minitest::Test
         def m1!: () -> ::Message::field_array?
 
         def initialize: (?m1: ::Message::array?) -> void
+                      | (record) -> void
 
         def []: (:m1) -> ::Message::field_array
               | (::Symbol) -> untyped
@@ -2177,7 +2199,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Foo | _ToProto
+        type init = Foo | _ToProto | record
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Foo, Foo | _ToProto]
@@ -2259,6 +2281,7 @@ class ProtobufGemTest < Minitest::Test
         def t1!: () -> ::Size?
 
         def initialize: (?t1: ::Size::init?) -> void
+                      | (record) -> void
 
         def []: (:t1) -> ::Size
               | (::Symbol) -> untyped
@@ -2273,7 +2296,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto
+        type init = Message | _ToProto | record
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -2355,6 +2378,7 @@ class ProtobufGemTest < Minitest::Test
         def t1!: () -> ::Size::field_array?
 
         def initialize: (?t1: ::Size::array?) -> void
+                      | (record) -> void
 
         def []: (:t1) -> ::Size::field_array
               | (::Symbol) -> untyped
@@ -2369,7 +2393,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto
+        type init = Message | _ToProto | record
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -2422,6 +2446,7 @@ class ProtobufGemTest < Minitest::Test
         def baz!: () -> ::String?
 
         def initialize: (?bar: ::String?, ?baz: ::String?) -> void
+                      | (record) -> void
 
         def []: (:bar) -> ::String
               | (:baz) -> ::String
@@ -2438,7 +2463,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Foo | _ToProto
+        type init = Foo | _ToProto | record
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Foo, Foo | _ToProto]
@@ -2520,6 +2545,7 @@ class ProtobufGemTest < Minitest::Test
           def baz!: () -> ::String?
 
           def initialize: (?bar: ::String?, ?baz: ::String?) -> void
+                        | (record) -> void
 
           def []: (:bar) -> ::String
                 | (:baz) -> ::String
@@ -2536,7 +2562,7 @@ class ProtobufGemTest < Minitest::Test
           end
 
           # The type of `#initialize` parameter.
-          type init = Foo | _ToProto
+          type init = Foo | _ToProto | record
 
           # The type of `repeated` field.
           type field_array = ::Protobuf::Field::FieldArray[Foo, Foo | _ToProto]


### PR DESCRIPTION
This PR adds `record` type that represents a hash which can be passed to `#initialize` method of messages.