### PR TITLE
Generate rpc method types and interfaces

### DIFF
--- a/test/protobuf_gem_test.rb
+++ b/test/protobuf_gem_test.rb
@@ -1639,6 +1639,21 @@ class ProtobufGemTest < Minitest::Test
       end
 
       class SearchService < ::Protobuf::Rpc::Service
+        interface _SearchMethod
+          def request: () -> ::SearchRequest
+
+          def respond_with: (::SearchResponse::init) -> void
+        end
+
+        def search: () -> void
+
+        interface _SendMessageMethod
+          def request: () -> ::Message
+
+          def respond_with: (::Message::init) -> void
+        end
+
+        def send_message: () -> void
       end
     RBS
   end


### PR DESCRIPTION
The service type has method definitions and the type of `self` inside the methods.

The type can be used like:

```ruby
class SearchService
  def search
    # @type self: SerchService & _SearchMethod

    response           # has type ::SearchRequest
    respond_with(...)  #: accepts ::SearchResponse::init type
  end
end
```

You need an extra type annotation, but it helps type checking the service implementation.

At least, the type definition tells the existence rpc methods and their types.