### PR TITLE
Add `RBS_PROTOBUF_CONCAT_LEVEL` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ You may need `bundle exec protoc ...` to let bundler set up PATH.
 * `RBS_PROTOBUF_EXTENSION` specifies what to do for extensions.
 * `RBS_PROTOBUF_ACCEPT_NIL_ATTR_WRITER` is to allow passing `nil` to required fields.
 * `RBS_PROTOBUF_FILTERS` contains filter Ruby script paths separated by `File::PATH_SEPARATOR`
+* `RBS_PROTOBUF_CONCAT_LEVEL` contains the number of dir levels that groups generated RBS files to concat
 
 ## Type checking
 

--- a/exe/protoc-gen-rbs
+++ b/exe/protoc-gen-rbs
@@ -58,6 +58,9 @@ translator = case backend
                raise NotImplementedError
              end
 
+if level = ENV["RBS_PROTOBUF_CONCAT_LEVEL"]
+  translator.rbs_concat_level = level.to_i
+end
 translator.generate_rbs!
 
 response = translator.response

--- a/lib/rbs_protobuf/translator/base.rb
+++ b/lib/rbs_protobuf/translator/base.rb
@@ -10,9 +10,9 @@ module RBSProtobuf
         @filters = filters
       end
 
-      def apply_filter(rbs_name, rbs_content, proto_file)
+      def apply_filter(rbs_name, rbs_content, proto_files)
         filters.inject([rbs_name, rbs_content]) do |(rbs_name, rbs_content), filter| #$ [String, String]
-          filter[rbs_name, rbs_content, proto_file]
+          filter[rbs_name, rbs_content, proto_files] or return
         end
       end
 
@@ -26,11 +26,12 @@ module RBSProtobuf
 
       def generate_rbs!
         input.proto_file.each do |file|
-          name, content = apply_filter(rbs_name(file.name), rbs_content(file), file)
-          response.file << Google::Protobuf::Compiler::CodeGeneratorResponse::File.new(
-            name: name,
-            content: content
-          )
+          if (name, content = apply_filter(rbs_name(file.name), rbs_content(file), [file]))
+            response.file << Google::Protobuf::Compiler::CodeGeneratorResponse::File.new(
+              name: name,
+              content: content
+            )
+          end
         end
       end
 

--- a/lib/rbs_protobuf/translator/base.rb
+++ b/lib/rbs_protobuf/translator/base.rb
@@ -26,13 +26,21 @@ module RBSProtobuf
 
       def generate_rbs!
         input.proto_file.each do |file|
-          if (name, content = apply_filter(rbs_name(file.name), rbs_content(file), [file]))
+          name = rbs_name(file.name)
+          decls = rbs_content(file)
+          if (name, content = apply_filter(name, format_rbs(decls: decls), [file]))
             response.file << Google::Protobuf::Compiler::CodeGeneratorResponse::File.new(
               name: name,
               content: content
             )
           end
         end
+      end
+
+      def format_rbs(dirs: [], decls: [])
+        StringIO.new.tap do |io|
+          RBS::Writer.new(out: io).write(dirs + decls)
+        end.string
       end
 
       def rbs_name(proto_name)

--- a/lib/rbs_protobuf/translator/protobuf_gem.rb
+++ b/lib/rbs_protobuf/translator/protobuf_gem.rb
@@ -49,7 +49,7 @@ module RBSProtobuf
       end
 
       def rbs_content(file)
-        decls = []
+        decls = [] #: Array[RBS::AST::Declarations::t]
 
         source_code_info = file.source_code_info
 
@@ -127,9 +127,7 @@ module RBSProtobuf
           end
         end
 
-        StringIO.new.tap do |io|
-          RBS::Writer.new(out: io).write(decls)
-        end.string
+        decls
       end
 
       def message_to_decl(message, prefix:, message_path:, source_code_info:, path:)

--- a/sig/rbs_protobuf/translator/base.rbs
+++ b/sig/rbs_protobuf/translator/base.rbs
@@ -27,7 +27,9 @@ module RBSProtobuf
 
       def rbs_suffix: () -> ::String
 
-      def rbs_content: (String file) -> String
+      def format_rbs: (?dirs: Array[RBS::AST::Directives::t], ?decls: Array[RBS::AST::Declarations::t]) -> String
+
+      def rbs_content: (String file) -> Array[RBS::AST::Declarations::t]
 
       def comment_for_path: (untyped source_code_info, Array[Integer] path, options: untyped) -> RBS::AST::Comment?
 

--- a/sig/rbs_protobuf/translator/base.rbs
+++ b/sig/rbs_protobuf/translator/base.rbs
@@ -9,6 +9,8 @@ module RBSProtobuf
 
       attr_reader filters: Array[filter]
 
+      attr_accessor rbs_concat_level: Integer?
+
       def initialize: (untyped input, ?Array[filter] filters) -> void
 
       def apply_filter: (String rbs_name, String rbs_content, Array[untyped] proto_file) -> [String, String]?

--- a/sig/rbs_protobuf/translator/base.rbs
+++ b/sig/rbs_protobuf/translator/base.rbs
@@ -5,13 +5,13 @@ module RBSProtobuf
 
       attr_reader input: untyped
 
-      type filter = ^(String rbs_name, String rbs_content, untyped proto_file) -> [String, String]
+      type filter = ^(String rbs_name, String rbs_content, Array[untyped] proto_files) -> [String, String]?
 
       attr_reader filters: Array[filter]
 
       def initialize: (untyped input, ?Array[filter] filters) -> void
 
-      def apply_filter: (String rbs_name, String rbs_content, untyped proto_file) -> [String, String]
+      def apply_filter: (String rbs_name, String rbs_content, Array[untyped] proto_file) -> [String, String]?
 
       @factory: RBSFactory
 

--- a/sig/rbs_protobuf/translator/protobuf_gem.rbs
+++ b/sig/rbs_protobuf/translator/protobuf_gem.rbs
@@ -64,7 +64,7 @@ module RBSProtobuf
       # The entry point.
       # Generate RBS declarations from the `file` and returns the string representation of the declarations.
       #
-      def rbs_content: (untyped file) -> String
+      def rbs_content: (untyped file) -> Array[RBS::AST::Declarations::t]
 
       # Returns the class declaration for given message.
       #

--- a/test/protobuf_gem_test.rb
+++ b/test/protobuf_gem_test.rb
@@ -2594,4 +2594,31 @@ class ProtobufGemTest < Minitest::Test
       end
     RBS
   end
+
+  def test_filter_return_nil
+    input = read_proto(<<~PROTO)
+      syntax = "proto3";
+
+      message Foo {
+        string bar = 1;
+        optional string baz = 2;
+      }
+    PROTO
+
+    filters = [
+      -> (name, content, file) { nil }
+    ]
+
+    translator = RBSProtobuf::Translator::ProtobufGem.new(
+      input,
+      filters,
+      upcase_enum: true,
+      nested_namespace: true,
+      extension: false,
+      accept_nil_writer: true
+    )
+    translator.generate_rbs!
+
+    assert_nil translator.response.file.find {|file| file.name == "hello.rbs" }
+  end
 end

--- a/test/protobuf_gem_test.rb
+++ b/test/protobuf_gem_test.rb
@@ -18,7 +18,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class Message < ::Protobuf::Message
@@ -62,7 +62,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class Message < ::Protobuf::Message
@@ -117,7 +117,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class Message < ::Protobuf::Message
@@ -172,7 +172,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class Message < ::Protobuf::Message
@@ -231,7 +231,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class Message < ::Protobuf::Message
@@ -291,7 +291,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class Message < ::Protobuf::Message
@@ -376,7 +376,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class Message < ::Protobuf::Message
@@ -461,7 +461,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class Message < ::Protobuf::Message
@@ -544,7 +544,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class Type < ::Protobuf::Enum
@@ -598,7 +598,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       # Protobuf options:
@@ -659,7 +659,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class Size < ::Protobuf::Enum
@@ -754,7 +754,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class Size < ::Protobuf::Enum
@@ -849,7 +849,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class Size < ::Protobuf::Enum
@@ -942,7 +942,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       module Foo
@@ -1012,7 +1012,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class Foo::Ba_r::Message < ::Protobuf::Message
@@ -1061,7 +1061,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class Message < ::Protobuf::Message
@@ -1123,7 +1123,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class Message < ::Protobuf::Message
@@ -1199,7 +1199,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class Foo < ::Protobuf::Enum
@@ -1293,7 +1293,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       module Test1
@@ -1379,7 +1379,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class M1 < ::Protobuf::Message
@@ -1466,7 +1466,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~'RBS', content
       class Account < ::Protobuf::Message
@@ -1566,7 +1566,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class SearchRequest < ::Protobuf::Message
@@ -1684,7 +1684,7 @@ class ProtobufGemTest < Minitest::Test
       extension: true,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       module Test
@@ -1768,7 +1768,7 @@ class ProtobufGemTest < Minitest::Test
       stderr: stderr,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       module Test
@@ -1825,7 +1825,7 @@ class ProtobufGemTest < Minitest::Test
       stderr: stderr,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       module Test
@@ -1890,7 +1890,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: false
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       # Protobuf options:
@@ -1953,7 +1953,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: true
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class Message < ::Protobuf::Message
@@ -2012,7 +2012,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: true
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class Message < ::Protobuf::Message
@@ -2076,7 +2076,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: true
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class Message < ::Protobuf::Message
@@ -2163,7 +2163,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: true
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class Message < ::Protobuf::Message
@@ -2252,7 +2252,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: true
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class Size < ::Protobuf::Enum
@@ -2349,7 +2349,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: true
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class Size < ::Protobuf::Enum
@@ -2442,7 +2442,7 @@ class ProtobufGemTest < Minitest::Test
       extension: false,
       accept_nil_writer: true
     )
-    content = translator.rbs_content(input.proto_file[0])
+    content = translator.format_rbs(decls: translator.rbs_content(input.proto_file[0]))
 
     assert_equal <<~RBS, content
       class Foo < ::Protobuf::Message


### PR DESCRIPTION
That concatenate generated RBS files based on the first components of its path.

    $ protoc ...    # generates RBS files for each .proto files
    $ RBS_PROTOBUF_CONCAT_LEVEL=1 protoc ...    # generates foo.rbs with foo/**/*.rbs contents
    $ RBS_PROTOBUF_CONCAT_LEVEL=2 protoc ...    # generates foo/bar.rbs with foo/bar/**/*.rbs contents

This helps reducing the number of generated RBS files, and may improve the type checking speed with Steep. (https://github.com/soutaro/steep/issues/661, This is a kind of bug of Steep and will be fixed.)
