### PR TITLE
Relaxed type definition for better compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,43 +8,57 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.7.2)
+    abbrev (0.1.1)
+    activesupport (7.1.2)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
     ast (2.4.2)
+    base64 (0.2.0)
+    bigdecimal (3.1.4)
     concurrent-ruby (1.2.2)
-    csv (3.2.7)
-    ffi (1.15.5)
-    fileutils (1.7.1)
+    connection_pool (2.4.1)
+    csv (3.2.8)
+    drb (2.2.0)
+      ruby2_keywords
+    ffi (1.16.3)
+    fileutils (1.7.2)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    json (2.6.3)
+    json (2.7.1)
     language_server-protocol (3.17.0.3)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.5.3)
+    logger (1.6.0)
     middleware (0.1.0)
-    minitest (5.19.0)
-    parser (3.2.2.3)
+    minitest (5.20.0)
+    mutex_m (0.2.0)
+    parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
-    protobuf (3.10.5)
+    protobuf (3.10.8)
       activesupport (>= 3.2)
       middleware
       thor
       thread_safe
-    racc (1.7.1)
+    racc (1.7.3)
     rainbow (3.1.1)
     rake (12.3.3)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rbs (3.1.3)
-    securerandom (0.2.2)
-    steep (1.5.3)
+    rbs (3.3.2)
+      abbrev
+    ruby2_keywords (0.0.5)
+    securerandom (0.3.0)
+    steep (1.6.0)
       activesupport (>= 5.1)
       concurrent-ruby (>= 1.1.10)
       csv (>= 3.0.9)
@@ -59,14 +73,14 @@ GEM
       securerandom (>= 0.1)
       strscan (>= 1.0.0)
       terminal-table (>= 2, < 4)
-    strscan (3.0.6)
+    strscan (3.0.7)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    thor (1.2.1)
+    thor (1.3.0)
     thread_safe (0.3.6)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.4.2)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
   ruby

--- a/example/d.proto
+++ b/example/d.proto
@@ -4,3 +4,7 @@ message Foo {
   string bar = 2;
   optional string baz = 1;
 }
+
+message Bar {
+  Foo foo = 1;
+}

--- a/example/protobuf_gem_example.rb
+++ b/example/protobuf_gem_example.rb
@@ -1,6 +1,7 @@
 require "protobuf"
 require_relative "protobuf-gem/a.pb.rb"
 require_relative "protobuf-gem/b.pb.rb"
+require_relative "protobuf-gem/d.pb.rb"
 
 request = Rbs_protobuf::Example::SearchRequest.decode("")
 request.corpus = :VIDEO
@@ -30,3 +31,11 @@ project.projects["sub project 1"] = Rbs_protobuf::Example::Project.new
 project = Rbs_protobuf::Example::Project.new
 s = project.new_name
 project.new_name = "Hello world"
+
+Rbs_protobuf::Example::Project.new(new_name: "Hello World")
+opts = { new_name: "Hello World" }
+Rbs_protobuf::Example::Project.new(opts)
+
+bar = Bar.new
+bar.foo = Foo.new
+bar.foo = {}

--- a/lib/rbs_protobuf/rbs_factory.rb
+++ b/lib/rbs_protobuf/rbs_factory.rb
@@ -129,6 +129,13 @@ module RBSProtobuf
       end
     end
 
+    def opts_type
+      RBS::BuiltinNames::Hash.instance_type(
+        RBS::BuiltinNames::Symbol.instance_type,
+        RBS::Types::Bases::Any.new(location: nil)
+      )
+    end
+
     def type_var(name, location: nil)
       Types::Variable.new(
         name: name,

--- a/lib/rbs_protobuf/translator/protobuf_gem.rb
+++ b/lib/rbs_protobuf/translator/protobuf_gem.rb
@@ -202,7 +202,12 @@ module RBSProtobuf
                 RBS::AST::Members::MethodDefinition::Overload.new(
                   method_type: factory.method_type(
                     type: factory.function().update(
-                      required_positionals: [factory.param(factory.alias_type("record"))]
+                      required_positionals: [
+                        factory.param(
+                          RBS::BuiltinNames::Hash.instance_type(RBS::BuiltinNames::Symbol.instance_type, factory.untyped),
+                          name: :attributes
+                        )
+                      ]
                     )
                   ),
                   annotations: []
@@ -362,8 +367,7 @@ module RBSProtobuf
             type_params: [],
             type: factory.union_type(
               class_instance_type,
-              TO_PROTO[],
-              field_types.empty? ? nil : factory.alias_type("record")
+              TO_PROTO[]
             ),
             annotations: [],
             comment: RBS::AST::Comment.new(string: "The type of `#initialize` parameter.", location: nil),
@@ -414,18 +418,6 @@ module RBSProtobuf
             annotations: [],
             comment: nil,
             location: nil
-          )
-
-          class_decl.members << RBS::AST::Declarations::TypeAlias.new(
-            name: TypeName("record"),
-            type_params: [],
-            type: RBS::Types::Record.new(
-              fields: field_types.transform_values {|_, _, type| optional_type(type) },
-              location: nil
-              ),
-            annotations: [],
-            location: nil,
-            comment: nil
           )
         end
       end

--- a/lib/rbs_protobuf/translator/protobuf_gem.rb
+++ b/lib/rbs_protobuf/translator/protobuf_gem.rb
@@ -514,7 +514,8 @@ module RBSProtobuf
                 [
                   factory.optional_type(type),
                   [
-                    factory.optional_type(message_to_proto_type(type))
+                    factory.optional_type(message_to_proto_type(type)),
+                    factory.optional_type(factory.opts_type)
                   ],
                   factory.optional_type(message_init_type(type))
                 ]
@@ -529,7 +530,7 @@ module RBSProtobuf
               else
                 [
                   type,
-                  [message_to_proto_type(type)],
+                  [message_to_proto_type(type), factory.opts_type],
                   message_init_type(type)
                 ]
               end

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -1,10 +1,4 @@
 ---
-sources:
-- type: git
-  name: ruby/gem_rbs_collection
-  revision: 5666e737d2b27a8425b4e3855c1a38cae54989f7
-  remote: https://github.com/ruby/gem_rbs_collection.git
-  repo_dir: gems
 path: ".gem_rbs_collection"
 gems:
 - name: abbrev
@@ -16,18 +10,42 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8a678b2ec20e9d594055f53745399814e3a887dc
+    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
+- name: base64
+  version: '0'
+  source:
+    type: stdlib
+- name: bigdecimal
+  version: '0'
+  source:
+    type: stdlib
 - name: concurrent-ruby
   version: '1.1'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8a678b2ec20e9d594055f53745399814e3a887dc
+    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: connection_pool
+  version: '2.4'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: date
+  version: '0'
+  source:
+    type: stdlib
+- name: erb
+  version: '0'
+  source:
+    type: stdlib
+- name: fileutils
   version: '0'
   source:
     type: stdlib
@@ -36,7 +54,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8a678b2ec20e9d594055f53745399814e3a887dc
+    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: json
@@ -72,11 +90,19 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8a678b2ec20e9d594055f53745399814e3a887dc
+    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rake
+  version: '13.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rbs
-  version: 3.1.3
+  version: 3.3.2
   source:
     type: rubygems
 - name: rdoc
@@ -91,7 +117,19 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: thor
+  version: '1.2'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: time
+  version: '0'
+  source:
+    type: stdlib
+- name: timeout
   version: '0'
   source:
     type: stdlib

--- a/sig/rbs_protobuf/rbs_factory.rbs
+++ b/sig/rbs_protobuf/rbs_factory.rbs
@@ -32,6 +32,9 @@ module RBSProtobuf
 
     def optional_type: (RBS::Types::t, ?location: RBS::Location[untyped, untyped]?) -> RBS::Types::Optional
 
+    # Type of *options hash* (`Hash[Symbol, untyped]`)
+    def opts_type: () -> RBS::Types::ClassInstance
+
     def type_var: (Symbol name, ?location: RBS::Location[untyped, untyped]?) -> RBS::Types::Variable
 
     def module_type_params: (*Symbol params) -> Array[RBS::AST::TypeParam]

--- a/test/protobuf_gem_test.rb
+++ b/test/protobuf_gem_test.rb
@@ -40,8 +40,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-        type record = { }
       end
     RBS
   end
@@ -71,7 +69,7 @@ class ProtobufGemTest < Minitest::Test
         def name!: () -> ::String?
 
         def initialize: (?name: ::String) -> void
-                      | (record) -> void
+                      | (::Hash[::Symbol, untyped] attributes) -> void
 
         def []: (:name) -> ::String
               | (::Symbol) -> untyped
@@ -84,7 +82,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto | record
+        type init = Message | _ToProto
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -95,8 +93,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-        type record = { name: ::String? }
       end
     RBS
   end
@@ -126,7 +122,7 @@ class ProtobufGemTest < Minitest::Test
         def name!: () -> ::String?
 
         def initialize: (?name: ::String) -> void
-                      | (record) -> void
+                      | (::Hash[::Symbol, untyped] attributes) -> void
 
         def []: (:name) -> ::String
               | (::Symbol) -> untyped
@@ -139,7 +135,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto | record
+        type init = Message | _ToProto
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -150,8 +146,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-        type record = { name: ::String? }
       end
     RBS
   end
@@ -184,7 +178,7 @@ class ProtobufGemTest < Minitest::Test
         def name!: () -> ::Protobuf::field_array[::String]?
 
         def initialize: (?name: ::Array[::String]) -> void
-                      | (record) -> void
+                      | (::Hash[::Symbol, untyped] attributes) -> void
 
         def []: (:name) -> ::Protobuf::field_array[::String]
               | (::Symbol) -> untyped
@@ -198,7 +192,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto | record
+        type init = Message | _ToProto
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -209,8 +203,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-        type record = { name: ::Array[::String]? }
       end
     RBS
   end
@@ -240,7 +232,7 @@ class ProtobufGemTest < Minitest::Test
         def name!: () -> bool?
 
         def initialize: (?name: bool) -> void
-                      | (record) -> void
+                      | (::Hash[::Symbol, untyped] attributes) -> void
 
         def []: (:name) -> bool
               | (::Symbol) -> untyped
@@ -255,7 +247,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto | record
+        type init = Message | _ToProto
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -266,8 +258,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-        type record = { name: bool? }
       end
     RBS
   end
@@ -313,8 +303,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-        type record = { }
       end
 
       class Foo < ::Protobuf::Message
@@ -326,7 +314,7 @@ class ProtobufGemTest < Minitest::Test
         def m1!: () -> ::Message?
 
         def initialize: (?m1: ::Message::init?) -> void
-                      | (record) -> void
+                      | (::Hash[::Symbol, untyped] attributes) -> void
 
         def []: (:m1) -> ::Message?
               | (::Symbol) -> untyped
@@ -340,7 +328,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Foo | _ToProto | record
+        type init = Foo | _ToProto
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Foo, Foo | _ToProto]
@@ -351,8 +339,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Foo | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Foo | _ToProto]
-
-        type record = { :m1 => ::Message::init? }
       end
     RBS
   end
@@ -398,8 +384,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-        type record = { }
       end
 
       class Foo < ::Protobuf::Message
@@ -411,7 +395,7 @@ class ProtobufGemTest < Minitest::Test
         def m1!: () -> ::Message?
 
         def initialize: (?m1: ::Message::init) -> void
-                      | (record) -> void
+                      | (::Hash[::Symbol, untyped] attributes) -> void
 
         def []: (:m1) -> ::Message
               | (::Symbol) -> untyped
@@ -425,7 +409,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Foo | _ToProto | record
+        type init = Foo | _ToProto
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Foo, Foo | _ToProto]
@@ -436,8 +420,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Foo | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Foo | _ToProto]
-
-        type record = { :m1 => ::Message::init? }
       end
     RBS
   end
@@ -483,8 +465,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-        type record = { }
       end
 
       class Foo < ::Protobuf::Message
@@ -496,7 +476,7 @@ class ProtobufGemTest < Minitest::Test
         def m1!: () -> ::Message::field_array?
 
         def initialize: (?m1: ::Message::array) -> void
-                      | (record) -> void
+                      | (::Hash[::Symbol, untyped] attributes) -> void
 
         def []: (:m1) -> ::Message::field_array
               | (::Symbol) -> untyped
@@ -510,7 +490,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Foo | _ToProto | record
+        type init = Foo | _ToProto
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Foo, Foo | _ToProto]
@@ -521,8 +501,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Foo | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Foo | _ToProto]
-
-        type record = { :m1 => ::Message::array? }
       end
     RBS
   end
@@ -702,7 +680,7 @@ class ProtobufGemTest < Minitest::Test
         def t1!: () -> ::Size?
 
         def initialize: (?t1: ::Size::init) -> void
-                      | (record) -> void
+                      | (::Hash[::Symbol, untyped] attributes) -> void
 
         def []: (:t1) -> ::Size
               | (::Symbol) -> untyped
@@ -716,7 +694,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto | record
+        type init = Message | _ToProto
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -727,8 +705,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-        type record = { :t1 => ::Size::init? }
       end
     RBS
   end
@@ -797,7 +773,7 @@ class ProtobufGemTest < Minitest::Test
         def t1!: () -> ::Size?
 
         def initialize: (?t1: ::Size::init) -> void
-                      | (record) -> void
+                      | (::Hash[::Symbol, untyped] attributes) -> void
 
         def []: (:t1) -> ::Size
               | (::Symbol) -> untyped
@@ -811,7 +787,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto | record
+        type init = Message | _ToProto
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -822,8 +798,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-        type record = { :t1 => ::Size::init? }
       end
     RBS
   end
@@ -892,7 +866,7 @@ class ProtobufGemTest < Minitest::Test
         def t1!: () -> ::Size::field_array?
 
         def initialize: (?t1: ::Size::array) -> void
-                      | (record) -> void
+                      | (::Hash[::Symbol, untyped] attributes) -> void
 
         def []: (:t1) -> ::Size::field_array
               | (::Symbol) -> untyped
@@ -906,7 +880,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto | record
+        type init = Message | _ToProto
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -917,8 +891,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-        type record = { :t1 => ::Size::array? }
       end
     RBS
   end
@@ -960,7 +932,7 @@ class ProtobufGemTest < Minitest::Test
             def replyTo!: () -> ::Foo::Ba_r::Message?
 
             def initialize: (?name: ::String, ?replyTo: ::Foo::Ba_r::Message::init?) -> void
-                          | (record) -> void
+                          | (::Hash[::Symbol, untyped] attributes) -> void
 
             def []: (:name) -> ::String
                   | (:replyTo) -> ::Foo::Ba_r::Message?
@@ -976,7 +948,7 @@ class ProtobufGemTest < Minitest::Test
             end
 
             # The type of `#initialize` parameter.
-            type init = Message | _ToProto | record
+            type init = Message | _ToProto
 
             # The type of `repeated` field.
             type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -987,8 +959,6 @@ class ProtobufGemTest < Minitest::Test
             type array = ::Array[Message | _ToProto]
 
             type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-            type record = { name: ::String?, replyTo: ::Foo::Ba_r::Message::init? }
           end
         end
       end
@@ -1034,8 +1004,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-        type record = { }
       end
     RBS
   end
@@ -1074,7 +1042,7 @@ class ProtobufGemTest < Minitest::Test
         def size!: () -> ::Integer?
 
         def initialize: (?name: ::String, ?size: ::Integer) -> void
-                      | (record) -> void
+                      | (::Hash[::Symbol, untyped] attributes) -> void
 
         def []: (:name) -> ::String
               | (:size) -> ::Integer
@@ -1089,7 +1057,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto | record
+        type init = Message | _ToProto
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -1100,8 +1068,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-        type record = { name: ::String?, size: ::Integer? }
       end
     RBS
   end
@@ -1142,7 +1108,7 @@ class ProtobufGemTest < Minitest::Test
         def messages!: () -> ::Message::field_hash[::Integer]?
 
         def initialize: (?numbers: ::Hash[::String, ::Integer], ?messages: ::Message::hash[::Integer]) -> void
-                      | (record) -> void
+                      | (::Hash[::Symbol, untyped] attributes) -> void
 
         def []: (:numbers) -> ::Protobuf::field_hash[::String, ::Integer]
               | (:messages) -> ::Message::field_hash[::Integer]
@@ -1159,7 +1125,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto | record
+        type init = Message | _ToProto
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -1170,8 +1136,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-        type record = { numbers: ::Hash[::String, ::Integer]?, messages: ::Message::hash[::Integer]? }
       end
     RBS
   end
@@ -1242,7 +1206,7 @@ class ProtobufGemTest < Minitest::Test
         def foos!: () -> ::Foo::field_hash[::String]?
 
         def initialize: (?foos: ::Foo::hash[::String]) -> void
-                      | (record) -> void
+                      | (::Hash[::Symbol, untyped] attributes) -> void
 
         def []: (:foos) -> ::Foo::field_hash[::String]
               | (::Symbol) -> untyped
@@ -1256,7 +1220,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto | record
+        type init = Message | _ToProto
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -1267,8 +1231,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-        type record = { foos: ::Foo::hash[::String]? }
       end
     RBS
   end
@@ -1307,7 +1269,7 @@ class ProtobufGemTest < Minitest::Test
             def foo!: () -> ::Protobuf::field_hash[::String, ::String]?
 
             def initialize: (?foo: ::Hash[::String, ::String]) -> void
-                          | (record) -> void
+                          | (::Hash[::Symbol, untyped] attributes) -> void
 
             def []: (:foo) -> ::Protobuf::field_hash[::String, ::String]
                   | (::Symbol) -> untyped
@@ -1321,7 +1283,7 @@ class ProtobufGemTest < Minitest::Test
             end
 
             # The type of `#initialize` parameter.
-            type init = Message2 | _ToProto | record
+            type init = Message2 | _ToProto
 
             # The type of `repeated` field.
             type field_array = ::Protobuf::Field::FieldArray[Message2, Message2 | _ToProto]
@@ -1332,8 +1294,6 @@ class ProtobufGemTest < Minitest::Test
             type array = ::Array[Message2 | _ToProto]
 
             type hash[KEY] = ::Hash[KEY, Message2 | _ToProto]
-
-            type record = { foo: ::Hash[::String, ::String]? }
           end
 
           def initialize: () -> void
@@ -1354,8 +1314,6 @@ class ProtobufGemTest < Minitest::Test
           type array = ::Array[Message | _ToProto]
 
           type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-          type record = { }
         end
       end
     RBS
@@ -1402,8 +1360,6 @@ class ProtobufGemTest < Minitest::Test
           type array = ::Array[M2 | _ToProto]
 
           type hash[KEY] = ::Hash[KEY, M2 | _ToProto]
-
-          type record = { }
         end
 
         attr_accessor m(): ::M1::M2?
@@ -1414,7 +1370,7 @@ class ProtobufGemTest < Minitest::Test
         def m!: () -> ::M1::M2?
 
         def initialize: (?m: ::M1::M2::init?) -> void
-                      | (record) -> void
+                      | (::Hash[::Symbol, untyped] attributes) -> void
 
         def []: (:m) -> ::M1::M2?
               | (::Symbol) -> untyped
@@ -1428,7 +1384,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = M1 | _ToProto | record
+        type init = M1 | _ToProto
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[M1, M1 | _ToProto]
@@ -1439,8 +1395,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[M1 | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, M1 | _ToProto]
-
-        type record = { m: ::M1::M2::init? }
       end
     RBS
   end
@@ -1509,7 +1463,7 @@ class ProtobufGemTest < Minitest::Test
         def type!: () -> ::Account::Type?
 
         def initialize: (?type: ::Account::Type::init) -> void
-                      | (record) -> void
+                      | (::Hash[::Symbol, untyped] attributes) -> void
 
         def []: (:type) -> ::Account::Type
               | (::Symbol) -> untyped
@@ -1523,7 +1477,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Account | _ToProto | record
+        type init = Account | _ToProto
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Account, Account | _ToProto]
@@ -1534,8 +1488,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Account | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Account | _ToProto]
-
-        type record = { type: ::Account::Type::init? }
       end
     RBS
   end
@@ -1588,8 +1540,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[SearchRequest | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, SearchRequest | _ToProto]
-
-        type record = { }
       end
 
       class SearchResponse < ::Protobuf::Message
@@ -1611,8 +1561,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[SearchResponse | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, SearchResponse | _ToProto]
-
-        type record = { }
       end
 
       class Message < ::Protobuf::Message
@@ -1634,8 +1582,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-        type record = { }
       end
 
       class SearchService < ::Protobuf::Rpc::Service
@@ -1707,8 +1653,6 @@ class ProtobufGemTest < Minitest::Test
           type array = ::Array[M1 | _ToProto]
 
           type hash[KEY] = ::Hash[KEY, M1 | _ToProto]
-
-          type record = { }
         end
       end
 
@@ -1791,8 +1735,6 @@ class ProtobufGemTest < Minitest::Test
           type array = ::Array[M1 | _ToProto]
 
           type hash[KEY] = ::Hash[KEY, M1 | _ToProto]
-
-          type record = { }
         end
       end
     RBS
@@ -1848,8 +1790,6 @@ class ProtobufGemTest < Minitest::Test
           type array = ::Array[M1 | _ToProto]
 
           type hash[KEY] = ::Hash[KEY, M1 | _ToProto]
-
-          type record = { }
         end
       end
     RBS
@@ -1907,7 +1847,7 @@ class ProtobufGemTest < Minitest::Test
         def name!: () -> ::String?
 
         def initialize: (?name: ::String) -> void
-                      | (record) -> void
+                      | (::Hash[::Symbol, untyped] attributes) -> void
 
         def []: (:name) -> ::String
               | (::Symbol) -> untyped
@@ -1920,7 +1860,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto | record
+        type init = Message | _ToProto
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -1931,8 +1871,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-        type record = { name: ::String? }
       end
     RBS
   end
@@ -1965,7 +1903,7 @@ class ProtobufGemTest < Minitest::Test
         def name!: () -> ::String?
 
         def initialize: (?name: ::String?) -> void
-                      | (record) -> void
+                      | (::Hash[::Symbol, untyped] attributes) -> void
 
         def []: (:name) -> ::String
               | (::Symbol) -> untyped
@@ -1979,7 +1917,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto | record
+        type init = Message | _ToProto
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -1990,8 +1928,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-        type record = { name: ::String? }
       end
     RBS
   end
@@ -2025,7 +1961,7 @@ class ProtobufGemTest < Minitest::Test
         def name!: () -> ::Protobuf::field_array[::String]?
 
         def initialize: (?name: ::Array[::String]?) -> void
-                      | (record) -> void
+                      | (::Hash[::Symbol, untyped] attributes) -> void
 
         def []: (:name) -> ::Protobuf::field_array[::String]
               | (::Symbol) -> untyped
@@ -2040,7 +1976,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto | record
+        type init = Message | _ToProto
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -2051,8 +1987,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-        type record = { name: ::Array[::String]? }
       end
     RBS
   end
@@ -2098,8 +2032,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-        type record = { }
       end
 
       class Foo < ::Protobuf::Message
@@ -2112,7 +2044,7 @@ class ProtobufGemTest < Minitest::Test
         def m1!: () -> ::Message?
 
         def initialize: (?m1: ::Message::init?) -> void
-                      | (record) -> void
+                      | (::Hash[::Symbol, untyped] attributes) -> void
 
         def []: (:m1) -> ::Message
               | (::Symbol) -> untyped
@@ -2127,7 +2059,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Foo | _ToProto | record
+        type init = Foo | _ToProto
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Foo, Foo | _ToProto]
@@ -2138,8 +2070,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Foo | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Foo | _ToProto]
-
-        type record = { :m1 => ::Message::init? }
       end
     RBS
   end
@@ -2185,8 +2115,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-        type record = { }
       end
 
       class Foo < ::Protobuf::Message
@@ -2199,7 +2127,7 @@ class ProtobufGemTest < Minitest::Test
         def m1!: () -> ::Message::field_array?
 
         def initialize: (?m1: ::Message::array?) -> void
-                      | (record) -> void
+                      | (::Hash[::Symbol, untyped] attributes) -> void
 
         def []: (:m1) -> ::Message::field_array
               | (::Symbol) -> untyped
@@ -2214,7 +2142,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Foo | _ToProto | record
+        type init = Foo | _ToProto
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Foo, Foo | _ToProto]
@@ -2225,8 +2153,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Foo | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Foo | _ToProto]
-
-        type record = { :m1 => ::Message::array? }
       end
     RBS
   end
@@ -2296,7 +2222,7 @@ class ProtobufGemTest < Minitest::Test
         def t1!: () -> ::Size?
 
         def initialize: (?t1: ::Size::init?) -> void
-                      | (record) -> void
+                      | (::Hash[::Symbol, untyped] attributes) -> void
 
         def []: (:t1) -> ::Size
               | (::Symbol) -> untyped
@@ -2311,7 +2237,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto | record
+        type init = Message | _ToProto
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -2322,8 +2248,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-        type record = { :t1 => ::Size::init? }
       end
     RBS
   end
@@ -2393,7 +2317,7 @@ class ProtobufGemTest < Minitest::Test
         def t1!: () -> ::Size::field_array?
 
         def initialize: (?t1: ::Size::array?) -> void
-                      | (record) -> void
+                      | (::Hash[::Symbol, untyped] attributes) -> void
 
         def []: (:t1) -> ::Size::field_array
               | (::Symbol) -> untyped
@@ -2408,7 +2332,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Message | _ToProto | record
+        type init = Message | _ToProto
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Message, Message | _ToProto]
@@ -2419,8 +2343,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Message | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Message | _ToProto]
-
-        type record = { :t1 => ::Size::array? }
       end
     RBS
   end
@@ -2461,7 +2383,7 @@ class ProtobufGemTest < Minitest::Test
         def baz!: () -> ::String?
 
         def initialize: (?bar: ::String?, ?baz: ::String?) -> void
-                      | (record) -> void
+                      | (::Hash[::Symbol, untyped] attributes) -> void
 
         def []: (:bar) -> ::String
               | (:baz) -> ::String
@@ -2478,7 +2400,7 @@ class ProtobufGemTest < Minitest::Test
         end
 
         # The type of `#initialize` parameter.
-        type init = Foo | _ToProto | record
+        type init = Foo | _ToProto
 
         # The type of `repeated` field.
         type field_array = ::Protobuf::Field::FieldArray[Foo, Foo | _ToProto]
@@ -2489,8 +2411,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Foo | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Foo | _ToProto]
-
-        type record = { bar: ::String?, baz: ::String? }
       end
     RBS
   end
@@ -2560,7 +2480,7 @@ class ProtobufGemTest < Minitest::Test
           def baz!: () -> ::String?
 
           def initialize: (?bar: ::String?, ?baz: ::String?) -> void
-                        | (record) -> void
+                        | (::Hash[::Symbol, untyped] attributes) -> void
 
           def []: (:bar) -> ::String
                 | (:baz) -> ::String
@@ -2577,7 +2497,7 @@ class ProtobufGemTest < Minitest::Test
           end
 
           # The type of `#initialize` parameter.
-          type init = Foo | _ToProto | record
+          type init = Foo | _ToProto
 
           # The type of `repeated` field.
           type field_array = ::Protobuf::Field::FieldArray[Foo, Foo | _ToProto]
@@ -2588,8 +2508,6 @@ class ProtobufGemTest < Minitest::Test
           type array = ::Array[Foo | _ToProto]
 
           type hash[KEY] = ::Hash[KEY, Foo | _ToProto]
-
-          type record = { bar: ::String?, baz: ::String? }
         end
       end
     RBS
@@ -2673,8 +2591,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Foo | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Foo | _ToProto]
-
-        type record = { }
       end
 
       class Bar < ::Protobuf::Message
@@ -2696,8 +2612,6 @@ class ProtobufGemTest < Minitest::Test
         type array = ::Array[Bar | _ToProto]
 
         type hash[KEY] = ::Hash[KEY, Bar | _ToProto]
-
-        type record = { }
       end
     RBS
   end

--- a/test/protobuf_gem_test.rb
+++ b/test/protobuf_gem_test.rb
@@ -309,6 +309,7 @@ class ProtobufGemTest < Minitest::Test
         attr_accessor m1(): ::Message?
 
         def m1=: [M < ::Message::_ToProto] (M?) -> M?
+               | (::Hash[::Symbol, untyped]?) -> ::Hash[::Symbol, untyped]?
                | ...
 
         def m1!: () -> ::Message?
@@ -321,6 +322,7 @@ class ProtobufGemTest < Minitest::Test
 
         def []=: (:m1, ::Message?) -> ::Message?
                | [M < ::Message::_ToProto] (:m1, M?) -> M?
+               | (:m1, ::Hash[::Symbol, untyped]?) -> ::Hash[::Symbol, untyped]?
                | (::Symbol, untyped) -> untyped
 
         interface _ToProto
@@ -390,6 +392,7 @@ class ProtobufGemTest < Minitest::Test
         attr_accessor m1(): ::Message
 
         def m1=: [M < ::Message::_ToProto] (M) -> M
+               | (::Hash[::Symbol, untyped]) -> ::Hash[::Symbol, untyped]
                | ...
 
         def m1!: () -> ::Message?
@@ -402,6 +405,7 @@ class ProtobufGemTest < Minitest::Test
 
         def []=: (:m1, ::Message) -> ::Message
                | [M < ::Message::_ToProto] (:m1, M) -> M
+               | (:m1, ::Hash[::Symbol, untyped]) -> ::Hash[::Symbol, untyped]
                | (::Symbol, untyped) -> untyped
 
         interface _ToProto
@@ -927,6 +931,7 @@ class ProtobufGemTest < Minitest::Test
             attr_accessor replyTo(): ::Foo::Ba_r::Message?
 
             def replyTo=: [M < ::Foo::Ba_r::Message::_ToProto] (M?) -> M?
+                        | (::Hash[::Symbol, untyped]?) -> ::Hash[::Symbol, untyped]?
                         | ...
 
             def replyTo!: () -> ::Foo::Ba_r::Message?
@@ -941,6 +946,7 @@ class ProtobufGemTest < Minitest::Test
             def []=: (:name, ::String) -> ::String
                    | (:replyTo, ::Foo::Ba_r::Message?) -> ::Foo::Ba_r::Message?
                    | [M < ::Foo::Ba_r::Message::_ToProto] (:replyTo, M?) -> M?
+                   | (:replyTo, ::Hash[::Symbol, untyped]?) -> ::Hash[::Symbol, untyped]?
                    | (::Symbol, untyped) -> untyped
 
             interface _ToProto
@@ -1365,6 +1371,7 @@ class ProtobufGemTest < Minitest::Test
         attr_accessor m(): ::M1::M2?
 
         def m=: [M < ::M1::M2::_ToProto] (M?) -> M?
+              | (::Hash[::Symbol, untyped]?) -> ::Hash[::Symbol, untyped]?
               | ...
 
         def m!: () -> ::M1::M2?
@@ -1377,6 +1384,7 @@ class ProtobufGemTest < Minitest::Test
 
         def []=: (:m, ::M1::M2?) -> ::M1::M2?
                | [M < ::M1::M2::_ToProto] (:m, M?) -> M?
+               | (:m, ::Hash[::Symbol, untyped]?) -> ::Hash[::Symbol, untyped]?
                | (::Symbol, untyped) -> untyped
 
         interface _ToProto
@@ -1674,6 +1682,7 @@ class ProtobufGemTest < Minitest::Test
         attr_accessor parent(): ::Test::M1?
 
         def parent=: [M < ::Test::M1::_ToProto] (M?) -> M?
+                   | (::Hash[::Symbol, untyped]?) -> ::Hash[::Symbol, untyped]?
                    | ...
 
         def parent!: () -> ::Test::M1?
@@ -1683,6 +1692,7 @@ class ProtobufGemTest < Minitest::Test
 
         def []=: (:parent, ::Test::M1?) -> ::Test::M1?
                | [M < ::Test::M1::_ToProto] (:parent, M?) -> M?
+               | (:parent, ::Hash[::Symbol, untyped]?) -> ::Hash[::Symbol, untyped]?
                | ...
       end
     RBS
@@ -2039,6 +2049,7 @@ class ProtobufGemTest < Minitest::Test
 
         def m1=: (::Message?) -> ::Message?
                | [M < ::Message::_ToProto] (M?) -> M?
+               | (::Hash[::Symbol, untyped]?) -> ::Hash[::Symbol, untyped]?
                | ...
 
         def m1!: () -> ::Message?
@@ -2052,6 +2063,7 @@ class ProtobufGemTest < Minitest::Test
         def []=: (:m1, ::Message) -> ::Message
                | (:m1, ::Message?) -> ::Message?
                | [M < ::Message::_ToProto] (:m1, M?) -> M?
+               | (:m1, ::Hash[::Symbol, untyped]?) -> ::Hash[::Symbol, untyped]?
                | (::Symbol, untyped) -> untyped
 
         interface _ToProto


### PR DESCRIPTION
This PR is to generates relaxed method type definitions for messages.

The methods accepts `Hash[Symbol, untyped]` if a protobuf message is required. This allows type checking existing Ruby code that uses `Hash` objects to specify attributes.

```ruby
opts = { name: "Ruby", url: "https://ruby-lang.org" }
Some::Service::Request.new(opts)            # The method accepts `Hash[Symbol, untyped]` to accept this code
```